### PR TITLE
slicefunc: package to abstract user-provided funcs

### DIFF
--- a/accum.go
+++ b/accum.go
@@ -5,9 +5,11 @@
 package bigslice
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/grailbio/bigslice/frame"
+	"github.com/grailbio/bigslice/slicefunc"
 	"github.com/grailbio/bigslice/sliceio"
 )
 
@@ -32,7 +34,7 @@ func canMakeAccumulatorForKey(keyType reflect.Type) bool {
 	}
 }
 
-func makeAccumulator(keyType, accType reflect.Type, fn reflect.Value) Accumulator {
+func makeAccumulator(keyType, accType reflect.Type, fn slicefunc.Func) Accumulator {
 	switch keyType.Kind() {
 	case reflect.String:
 		return &stringAccumulator{
@@ -60,11 +62,12 @@ func makeAccumulator(keyType, accType reflect.Type, fn reflect.Value) Accumulato
 // StringAccumulator accumulates values by string keys.
 type stringAccumulator struct {
 	accType reflect.Type
-	fn      reflect.Value
+	fn      slicefunc.Func
 	state   map[string]reflect.Value
 }
 
 func (s *stringAccumulator) Accumulate(in frame.Frame, n int) {
+	ctx := context.Background()
 	keys := in.Interface(0).([]string)
 	args := make([]reflect.Value, in.NumOut())
 	for i := 0; i < n; i++ {
@@ -77,7 +80,7 @@ func (s *stringAccumulator) Accumulate(in frame.Frame, n int) {
 		for j := 1; j < in.NumOut(); j++ {
 			args[j] = in.Index(j, i)
 		}
-		s.state[key] = s.fn.Call(args)[0]
+		s.state[key] = s.fn.Call(ctx, args)[0]
 	}
 }
 
@@ -101,11 +104,12 @@ func (s *stringAccumulator) Read(keys, values reflect.Value) (n int, err error) 
 // IntAccumulator accumulates values by integer keys.
 type intAccumulator struct {
 	accType reflect.Type
-	fn      reflect.Value
+	fn      slicefunc.Func
 	state   map[int]reflect.Value
 }
 
 func (s *intAccumulator) Accumulate(in frame.Frame, n int) {
+	ctx := context.Background()
 	keys := in.Interface(0).([]int)
 	args := make([]reflect.Value, in.NumOut())
 	for i := 0; i < n; i++ {
@@ -118,7 +122,7 @@ func (s *intAccumulator) Accumulate(in frame.Frame, n int) {
 		for j := 1; j < in.NumOut(); j++ {
 			args[j] = in.Index(j, i)
 		}
-		s.state[key] = s.fn.Call(args)[0]
+		s.state[key] = s.fn.Call(ctx, args)[0]
 	}
 }
 
@@ -142,11 +146,12 @@ func (s *intAccumulator) Read(keys, values reflect.Value) (n int, err error) {
 // Int64Accumulator accumulates values by integer keys.
 type int64Accumulator struct {
 	accType reflect.Type
-	fn      reflect.Value
+	fn      slicefunc.Func
 	state   map[int64]reflect.Value
 }
 
 func (s *int64Accumulator) Accumulate(in frame.Frame, n int) {
+	ctx := context.Background()
 	keys := in.Interface(0).([]int64)
 	args := make([]reflect.Value, in.NumOut())
 	for i := 0; i < n; i++ {
@@ -159,7 +164,7 @@ func (s *int64Accumulator) Accumulate(in frame.Frame, n int) {
 		for j := 1; j < in.NumOut(); j++ {
 			args[j] = in.Index(j, i)
 		}
-		s.state[key] = s.fn.Call(args)[0]
+		s.state[key] = s.fn.Call(ctx, args)[0]
 	}
 }
 

--- a/accum_test.go
+++ b/accum_test.go
@@ -10,6 +10,7 @@ import (
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/grailbio/bigslice/frame"
+	"github.com/grailbio/bigslice/slicefunc"
 	"github.com/grailbio/bigslice/sliceio"
 )
 
@@ -28,7 +29,7 @@ outer:
 			t.Errorf("expected to be able to make accumulator for %s", typ)
 			continue
 		}
-		step := reflect.ValueOf(func(a, e int) int { return a + e })
+		step := slicefunc.Of(func(a, e int) int { return a + e })
 		accum := makeAccumulator(typ, typeOfInt, step)
 		const N = 100
 		for i := 0; i < N; i++ {

--- a/cache.go
+++ b/cache.go
@@ -6,9 +6,9 @@ package bigslice
 
 import (
 	"context"
-	"reflect"
 
 	"github.com/grailbio/bigslice/internal/slicecache"
+	"github.com/grailbio/bigslice/slicefunc"
 	"github.com/grailbio/bigslice/sliceio"
 )
 
@@ -23,7 +23,7 @@ var _ slicecache.Cacheable = (*cacheSlice)(nil)
 func (c *cacheSlice) Name() Name                                             { return c.name }
 func (c *cacheSlice) NumDep() int                                            { return 1 }
 func (c *cacheSlice) Dep(i int) Dep                                          { return Dep{c.Slice, false, false} }
-func (*cacheSlice) Combiner() *reflect.Value                                 { return nil }
+func (*cacheSlice) Combiner() slicefunc.Func                                 { return slicefunc.Nil }
 func (c *cacheSlice) Reader(shard int, deps []sliceio.Reader) sliceio.Reader { return deps[0] }
 
 func (c *cacheSlice) Cache() *slicecache.ShardCache { return c.cache }

--- a/cogroup.go
+++ b/cogroup.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 
 	"github.com/grailbio/bigslice/frame"
+	"github.com/grailbio/bigslice/slicefunc"
 	"github.com/grailbio/bigslice/sliceio"
 	"github.com/grailbio/bigslice/slicetype"
 	"github.com/grailbio/bigslice/sortio"
@@ -108,7 +109,7 @@ func (c *cogroupSlice) Out(i int) reflect.Type { return c.out[i] }
 func (c *cogroupSlice) Prefix() int            { return c.prefix }
 func (c *cogroupSlice) NumDep() int            { return len(c.slices) }
 func (c *cogroupSlice) Dep(i int) Dep          { return Dep{c.slices[i], true, false} }
-func (*cogroupSlice) Combiner() *reflect.Value { return nil }
+func (*cogroupSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 type cogroupReader struct {
 	err error

--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -802,7 +802,7 @@ func (w *worker) Run(ctx context.Context, req taskRunRequest, reply *taskRunRepl
 
 	// If we have a combiner, then we partition globally for the machine
 	// into common combiners.
-	if task.Combiner != nil {
+	if !task.Combiner.IsNil() {
 		return w.runCombine(ctx, task, taskStats, task.Do(in))
 	}
 
@@ -958,7 +958,7 @@ func (w *worker) runCombine(ctx context.Context, task *Task, taskStats *stats.Ma
 	case combinerNone:
 		combiners := make([]chan *combiner, task.NumPartition)
 		for i := range combiners {
-			comb, err := newCombiner(task, fmt.Sprintf("%s%d", combineKey, i), *task.Combiner, *defaultChunksize*100)
+			comb, err := newCombiner(task, fmt.Sprintf("%s%d", combineKey, i), task.Combiner, *defaultChunksize*100)
 			if err != nil {
 				w.mu.Unlock()
 				for j := 0; j < i; j++ {
@@ -1003,7 +1003,7 @@ func (w *worker) runCombine(ctx context.Context, task *Task, taskStats *stats.Ma
 		out               = frame.Make(task, *defaultChunksize, *defaultChunksize)
 	)
 	for i := range partitionCombiner {
-		partitionCombiner[i] = makeCombiningFrame(task, *task.Combiner, 8, 1)
+		partitionCombiner[i] = makeCombiningFrame(task, task.Combiner, 8, 1)
 	}
 	for {
 		n, err := in.Read(ctx, out)

--- a/exec/combiner_test.go
+++ b/exec/combiner_test.go
@@ -13,6 +13,7 @@ import (
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/grailbio/bigslice/frame"
+	"github.com/grailbio/bigslice/slicefunc"
 	"github.com/grailbio/bigslice/sliceio"
 	"github.com/grailbio/bigslice/slicetype"
 )
@@ -36,7 +37,7 @@ func deepEqual(f, g frame.Frame) bool {
 
 func TestCombiningFrame(t *testing.T) {
 	typ := slicetype.New(typeOfString, typeOfInt)
-	f := makeCombiningFrame(typ, reflect.ValueOf(func(n, m int) int { return n + m }), 2, 1)
+	f := makeCombiningFrame(typ, slicefunc.Of(func(n, m int) int { return n + m }), 2, 1)
 	if f == nil {
 		t.Fatal("nil frame")
 	}
@@ -64,7 +65,7 @@ func TestCombiningFrame(t *testing.T) {
 func TestCombiningFrameManyKeys(t *testing.T) {
 	const N = 100000
 	typ := slicetype.New(typeOfString, typeOfInt)
-	f := makeCombiningFrame(typ, reflect.ValueOf(func(n, m int) int { return n + m }), 2, 1)
+	f := makeCombiningFrame(typ, slicefunc.Of(func(n, m int) int { return n + m }), 2, 1)
 	if f == nil {
 		t.Fatal("nil frame")
 	}
@@ -113,7 +114,7 @@ func TestCombiner(t *testing.T) {
 	const N = 100
 	typ := slicetype.New(typeOfString, typeOfInt)
 	// Set a small target value to ensure spilling.
-	c, err := newCombiner(typ, "test", reflect.ValueOf(func(n, m int) int { return n + m }), 2)
+	c, err := newCombiner(typ, "test", slicefunc.Of(func(n, m int) int { return n + m }), 2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exec/local.go
+++ b/exec/local.go
@@ -65,13 +65,13 @@ func (l *localExecutor) Run(task *Task) {
 		for j := 0; j < dep.NumTask(); j++ {
 			reader.q[j] = l.Reader(dep.Task(j), dep.Partition)
 		}
-		if dep.NumTask() > 0 && dep.Task(0).Combiner != nil {
+		if dep.NumTask() > 0 && !dep.Task(0).Combiner.IsNil() {
 			// Perform input combination in-line, one for each partition.
 			combineKey := task.Name
 			if task.CombineKey != "" {
 				combineKey = TaskName{Op: task.CombineKey}
 			}
-			combiner, err := newCombiner(dep.Task(0), combineKey.String(), *dep.Task(0).Combiner, *defaultChunksize*100)
+			combiner, err := newCombiner(dep.Task(0), combineKey.String(), dep.Task(0).Combiner, *defaultChunksize*100)
 			if err != nil {
 				task.Error(err)
 				return

--- a/exec/task.go
+++ b/exec/task.go
@@ -234,7 +234,7 @@ type Task struct {
 	NumPartition int
 
 	// Combiner specifies an (optional) combiner to use for this task's output.
-	// If a Combiner is not Nil(), CombineKey names the combine buffer used:
+	// If a Combiner is not Nil, CombineKey names the combine buffer used:
 	// each combine buffer contains combiner outputs from multiple tasks.
 	// If CombineKey is not set, then per-task buffers are used instead.
 	Combiner   slicefunc.Func

--- a/exec/task.go
+++ b/exec/task.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -19,6 +18,7 @@ import (
 	"github.com/grailbio/base/status"
 	"github.com/grailbio/base/sync/ctxsync"
 	"github.com/grailbio/bigslice"
+	"github.com/grailbio/bigslice/slicefunc"
 	"github.com/grailbio/bigslice/sliceio"
 	"github.com/grailbio/bigslice/slicetype"
 )
@@ -234,10 +234,10 @@ type Task struct {
 	NumPartition int
 
 	// Combiner specifies an (optional) combiner to use for this task's output.
-	// If a Combiner is specified, CombineKey names the combine buffer used:
+	// If a Combiner is not Nil(), CombineKey names the combine buffer used:
 	// each combine buffer contains combiner outputs from multiple tasks.
 	// If CombineKey is not set, then per-task buffers are used instead.
-	Combiner   *reflect.Value
+	Combiner   slicefunc.Func
 	CombineKey string
 
 	// Pragma comprises the pragmas of all slice operations that

--- a/reduce.go
+++ b/reduce.go
@@ -6,10 +6,10 @@ package bigslice
 
 import (
 	"fmt"
-	"reflect"
 	"strings"
 
 	"github.com/grailbio/bigslice/frame"
+	"github.com/grailbio/bigslice/slicefunc"
 	"github.com/grailbio/bigslice/sliceio"
 	"github.com/grailbio/bigslice/slicetype"
 	"github.com/grailbio/bigslice/sortio"
@@ -54,20 +54,20 @@ func Reduce(slice Slice, reduce interface{}) Slice {
 	if arg.NumOut() != 2 || arg.Out(0) != outputType || arg.Out(1) != outputType || ret.NumOut() != 1 || ret.Out(0) != outputType {
 		typecheck.Panicf(1, "reduce: invalid reduce function %T, expected func(%s, %s) %s", reduce, outputType, outputType, outputType)
 	}
-	return &reduceSlice{slice, makeName("reduce"), reflect.ValueOf(reduce)}
+	return &reduceSlice{slice, makeName("reduce"), slicefunc.Of(reduce)}
 }
 
 // ReduceSlice implements "post shuffle" combining merge sort.
 type reduceSlice struct {
 	Slice
 	name     Name
-	combiner reflect.Value
+	combiner slicefunc.Func
 }
 
 func (r *reduceSlice) Name() Name               { return r.name }
 func (*reduceSlice) NumDep() int                { return 1 }
 func (r *reduceSlice) Dep(i int) Dep            { return Dep{r.Slice, true, true} }
-func (r *reduceSlice) Combiner() *reflect.Value { return &r.combiner }
+func (r *reduceSlice) Combiner() slicefunc.Func { return r.combiner }
 
 func (r *reduceSlice) Reader(shard int, deps []sliceio.Reader) sliceio.Reader {
 	if len(deps) == 1 {

--- a/reshard.go
+++ b/reshard.go
@@ -6,8 +6,8 @@ package bigslice
 
 import (
 	"fmt"
-	"reflect"
 
+	"github.com/grailbio/bigslice/slicefunc"
 	"github.com/grailbio/bigslice/sliceio"
 	"github.com/grailbio/bigslice/typecheck"
 )
@@ -35,7 +35,7 @@ func (r *reshardSlice) Name() Name             { return r.name }
 func (*reshardSlice) NumDep() int              { return 1 }
 func (r *reshardSlice) NumShard() int          { return r.nshard }
 func (r *reshardSlice) Dep(i int) Dep          { return Dep{r.Slice, true, false} }
-func (*reshardSlice) Combiner() *reflect.Value { return nil }
+func (*reshardSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 func (r *reshardSlice) Reader(shard int, deps []sliceio.Reader) sliceio.Reader {
 	if len(deps) != 1 {

--- a/reshuffle.go
+++ b/reshuffle.go
@@ -6,8 +6,8 @@ package bigslice
 
 import (
 	"fmt"
-	"reflect"
 
+	"github.com/grailbio/bigslice/slicefunc"
 	"github.com/grailbio/bigslice/sliceio"
 	"github.com/grailbio/bigslice/typecheck"
 )
@@ -34,7 +34,7 @@ func Reshuffle(slice Slice) Slice {
 func (r *reshuffleSlice) Name() Name             { return r.name }
 func (*reshuffleSlice) NumDep() int              { return 1 }
 func (r *reshuffleSlice) Dep(i int) Dep          { return Dep{r.Slice, true, false} }
-func (*reshuffleSlice) Combiner() *reflect.Value { return nil }
+func (*reshuffleSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 func (r *reshuffleSlice) Reader(shard int, deps []sliceio.Reader) sliceio.Reader {
 	if len(deps) != 1 {

--- a/slice.go
+++ b/slice.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grailbio/base/log"
 	"github.com/grailbio/bigslice/frame"
 	"github.com/grailbio/bigslice/internal/defaultsize"
+	"github.com/grailbio/bigslice/slicefunc"
 	"github.com/grailbio/bigslice/sliceio"
 	"github.com/grailbio/bigslice/slicetype"
 	"github.com/grailbio/bigslice/typecheck"
@@ -89,8 +90,8 @@ type Slice interface {
 
 	// Combiner is an optional function that is used to combine multiple
 	// values with the same key from the slice's output. No combination
-	// is performed if nil.
-	Combiner() *reflect.Value
+	// is performed if empty.
+	Combiner() slicefunc.Func
 
 	// Reader returns a Reader for a shard of this Slice. The reader
 	// itself computes the shard's values on demand. The caller must
@@ -196,7 +197,7 @@ func (s *constSlice) NumShard() int          { return s.nshard }
 func (*constSlice) ShardType() ShardType     { return HashShard }
 func (*constSlice) NumDep() int              { return 0 }
 func (*constSlice) Dep(i int) Dep            { panic("no deps") }
-func (*constSlice) Combiner() *reflect.Value { return nil }
+func (*constSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 type constReader struct {
 	op    *constSlice
@@ -246,7 +247,7 @@ type readerFuncSlice struct {
 	Pragma
 	slicetype.Type
 	nshard    int
-	read      reflect.Value
+	read      slicefunc.Func
 	stateType reflect.Type
 }
 
@@ -274,11 +275,11 @@ func ReaderFunc(nshard int, read interface{}, prags ...Pragma) Slice {
 	s := new(readerFuncSlice)
 	s.name = makeName("reader")
 	s.nshard = nshard
-	s.read = reflect.ValueOf(read)
 	arg, ret, ok := typecheck.Func(read)
 	if !ok || arg.NumOut() < 3 || arg.Out(0).Kind() != reflect.Int {
 		typecheck.Panicf(1, "readerfunc: invalid reader function type %T", read)
 	}
+	s.read = slicefunc.Of(read)
 	if ret.Out(0).Kind() != reflect.Int || ret.Out(1) != typeOfError {
 		typecheck.Panicf(1, "readerfunc: function %T does not return (int, error)", read)
 	}
@@ -297,7 +298,7 @@ func (r *readerFuncSlice) NumShard() int          { return r.nshard }
 func (*readerFuncSlice) ShardType() ShardType     { return HashShard }
 func (*readerFuncSlice) NumDep() int              { return 0 }
 func (*readerFuncSlice) Dep(i int) Dep            { panic("no deps") }
-func (*readerFuncSlice) Combiner() *reflect.Value { return nil }
+func (*readerFuncSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 type readerFuncSliceReader struct {
 	op    *readerFuncSlice
@@ -327,7 +328,7 @@ func (r *readerFuncSliceReader) Read(ctx context.Context, out frame.Frame) (n in
 	}
 	// out is passed to a user, zero it.
 	out.Zero()
-	rvs := r.op.read.Call(append([]reflect.Value{reflect.ValueOf(r.shard), r.state}, out.Values()...))
+	rvs := r.op.read.Call(ctx, append([]reflect.Value{reflect.ValueOf(r.shard), r.state}, out.Values()...))
 	n = int(rvs[0].Int())
 	if n == 0 {
 		r.consecutiveEmptyCalls++
@@ -357,7 +358,7 @@ type writerFuncSlice struct {
 	name Name
 	Slice
 	stateType reflect.Type
-	write     reflect.Value
+	write     slicefunc.Func
 }
 
 // WriterFunc returns a Slice that is functionally equivalent to the input
@@ -422,25 +423,25 @@ func WriterFunc(slice Slice, write interface{}) Slice {
 	if ret.NumOut() != 1 || ret.Out(0) != typeOfError {
 		die("must return error")
 	}
-	s.write = reflect.ValueOf(write)
+	s.write = slicefunc.Of(write)
 	return s
 }
 
 func (s *writerFuncSlice) Name() Name             { return s.name }
 func (*writerFuncSlice) NumDep() int              { return 1 }
 func (s *writerFuncSlice) Dep(i int) Dep          { return singleDep(i, s.Slice, false) }
-func (*writerFuncSlice) Combiner() *reflect.Value { return nil }
+func (*writerFuncSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 type writerFuncReader struct {
 	shard     int
-	write     reflect.Value
+	write     slicefunc.Func
 	reader    sliceio.Reader
 	stateType reflect.Type
 	state     reflect.Value
 	err       error
 }
 
-func (r *writerFuncReader) callWrite(err error, frame frame.Frame) error {
+func (r *writerFuncReader) callWrite(ctx context.Context, err error, frame frame.Frame) error {
 	args := []reflect.Value{reflect.ValueOf(r.shard), r.state}
 
 	// TODO(jcharumilind): Cache error and column arguments, as they will
@@ -454,7 +455,7 @@ func (r *writerFuncReader) callWrite(err error, frame frame.Frame) error {
 	args = append(args, errArg)
 
 	args = append(args, frame.Values()...)
-	rvs := r.write.Call(args)
+	rvs := r.write.Call(ctx, args)
 	if e := rvs[0].Interface(); e != nil {
 		return e.(error)
 	}
@@ -474,7 +475,7 @@ func (r *writerFuncReader) Read(ctx context.Context, out frame.Frame) (int, erro
 	}
 
 	n, err := r.reader.Read(ctx, out)
-	werr := r.callWrite(err, out.Slice(0, n))
+	werr := r.callWrite(ctx, err, out.Slice(0, n))
 	if werr != nil && (err == nil || err == sliceio.EOF) {
 		if errors.IsTemporary(werr) {
 			err = werr
@@ -499,7 +500,7 @@ type mapSlice struct {
 	name Name
 	Pragma
 	Slice
-	fval reflect.Value
+	fval slicefunc.Func
 	out  slicetype.Type
 }
 
@@ -516,7 +517,6 @@ func Map(slice Slice, fn interface{}, prags ...Pragma) Slice {
 	m := new(mapSlice)
 	m.name = makeName("map")
 	m.Slice = slice
-	m.fval = reflect.ValueOf(fn)
 	arg, ret, ok := typecheck.Func(fn)
 	if !ok {
 		typecheck.Panicf(1, "map: invalid map function %T", fn)
@@ -527,6 +527,7 @@ func Map(slice Slice, fn interface{}, prags ...Pragma) Slice {
 	if ret.NumOut() == 0 {
 		typecheck.Panicf(1, "map: need at least one output column")
 	}
+	m.fval = slicefunc.Of(fn)
 	m.out = ret
 	m.Pragma = Pragmas(prags)
 	return m
@@ -538,7 +539,7 @@ func (m *mapSlice) Out(c int) reflect.Type { return m.out.Out(c) }
 func (*mapSlice) ShardType() ShardType     { return HashShard }
 func (*mapSlice) NumDep() int              { return 1 }
 func (m *mapSlice) Dep(i int) Dep          { return singleDep(i, m.Slice, false) }
-func (*mapSlice) Combiner() *reflect.Value { return nil }
+func (*mapSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 type mapReader struct {
 	op     *mapSlice
@@ -575,7 +576,7 @@ func (m *mapReader) Read(ctx context.Context, out frame.Frame) (int, error) {
 			args[j] = m.in.Index(j, i)
 		}
 		// TODO(marius): consider using an unsafe copy here
-		result := m.op.fval.Call(args)
+		result := m.op.fval.Call(ctx, args)
 		for j := range result {
 			out.Index(j, i).Set(result[j])
 		}
@@ -591,7 +592,7 @@ type filterSlice struct {
 	name Name
 	Pragma
 	Slice
-	pred reflect.Value
+	pred slicefunc.Func
 }
 
 // Filter returns a slice where the provided predicate is applied to
@@ -608,7 +609,6 @@ func Filter(slice Slice, pred interface{}, prags ...Pragma) Slice {
 	f := new(filterSlice)
 	f.name = makeName("filter")
 	f.Slice = slice
-	f.pred = reflect.ValueOf(pred)
 	f.Pragma = Pragmas(prags)
 	arg, ret, ok := typecheck.Func(pred)
 	if !ok {
@@ -620,13 +620,14 @@ func Filter(slice Slice, pred interface{}, prags ...Pragma) Slice {
 	if ret.NumOut() != 1 || ret.Out(0).Kind() != reflect.Bool {
 		typecheck.Panic(1, "filter: predicate must return a single boolean value")
 	}
+	f.pred = slicefunc.Of(pred)
 	return f
 }
 
 func (f *filterSlice) Name() Name             { return f.name }
 func (*filterSlice) NumDep() int              { return 1 }
 func (f *filterSlice) Dep(i int) Dep          { return singleDep(i, f.Slice, false) }
-func (*filterSlice) Combiner() *reflect.Value { return nil }
+func (*filterSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 type filterReader struct {
 	op     *filterSlice
@@ -662,7 +663,7 @@ func (f *filterReader) Read(ctx context.Context, out frame.Frame) (n int, err er
 			for j := range args {
 				args[j] = f.in.Value(j).Index(i)
 			}
-			if f.op.pred.Call(args)[0].Bool() {
+			if f.op.pred.Call(ctx, args)[0].Bool() {
 				frame.Copy(out.Slice(m, m+1), f.in.Slice(i, i+1))
 				m++
 			}
@@ -679,7 +680,7 @@ type flatmapSlice struct {
 	name Name
 	Pragma
 	Slice
-	fval reflect.Value
+	fval slicefunc.Func
 	out  slicetype.Type
 }
 
@@ -696,7 +697,6 @@ func Flatmap(slice Slice, fn interface{}, prags ...Pragma) Slice {
 	f := new(flatmapSlice)
 	f.name = makeName("flatmap")
 	f.Slice = slice
-	f.fval = reflect.ValueOf(fn)
 	f.Pragma = Pragmas(prags)
 	arg, ret, ok := typecheck.Func(fn)
 	if !ok {
@@ -709,6 +709,7 @@ func Flatmap(slice Slice, fn interface{}, prags ...Pragma) Slice {
 	if !ok {
 		typecheck.Panicf(1, "flatmap: flatmap function %T is not vectorized", fn)
 	}
+	f.fval = slicefunc.Of(fn)
 	return f
 }
 
@@ -718,7 +719,7 @@ func (f *flatmapSlice) Out(c int) reflect.Type { return f.out.Out(c) }
 func (*flatmapSlice) ShardType() ShardType     { return HashShard }
 func (*flatmapSlice) NumDep() int              { return 1 }
 func (f *flatmapSlice) Dep(i int) Dep          { return singleDep(i, f.Slice, false) }
-func (*flatmapSlice) Combiner() *reflect.Value { return nil }
+func (*flatmapSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 type flatmapReader struct {
 	op     *flatmapSlice
@@ -767,7 +768,7 @@ func (f *flatmapReader) Read(ctx context.Context, out frame.Frame) (int, error) 
 			for j := range args {
 				args[j] = f.in.Index(j, f.begIn)
 			}
-			result := frame.Values(f.op.fval.Call(args))
+			result := frame.Values(f.op.fval.Call(ctx, args))
 			n := frame.Copy(out.Slice(begOut, endOut), result)
 			begOut += n
 			// We've run out of output space. In this case, stash the rest of
@@ -793,7 +794,7 @@ func (f *flatmapSlice) Reader(shard int, deps []sliceio.Reader) sliceio.Reader {
 type foldSlice struct {
 	name Name
 	Slice
-	fval reflect.Value
+	fval slicefunc.Func
 	out  slicetype.Type
 	dep  Dep
 }
@@ -833,7 +834,6 @@ func Fold(slice Slice, fold interface{}) Slice {
 	// Fold requires shuffle by the first column.
 	// TODO(marius): allow deps to express shuffling by other columns.
 	f.dep = Dep{slice, true, false}
-	f.fval = reflect.ValueOf(fold)
 
 	arg, ret, ok := typecheck.Func(fold)
 	if !ok {
@@ -846,6 +846,7 @@ func Fold(slice Slice, fold interface{}) Slice {
 	if got, want := arg, slicetype.Append(ret, slicetype.Slice(slice, 1, slice.NumOut())); !typecheck.Equal(got, want) {
 		typecheck.Panicf(1, "fold: expected func(acc, t2, t3, ..., tn), got %T", fold)
 	}
+	f.fval = slicefunc.Of(fold)
 	// output: key, accumulator
 	f.out = slicetype.New(slice.Out(0), ret.Out(0))
 	return f
@@ -856,7 +857,7 @@ func (f *foldSlice) NumOut() int            { return f.out.NumOut() }
 func (f *foldSlice) Out(c int) reflect.Type { return f.out.Out(c) }
 func (*foldSlice) NumDep() int              { return 1 }
 func (f *foldSlice) Dep(i int) Dep          { return f.dep }
-func (*foldSlice) Combiner() *reflect.Value { return nil }
+func (*foldSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 type foldReader struct {
 	op     *foldSlice
@@ -920,7 +921,7 @@ func Head(slice Slice, n int) Slice {
 func (h *headSlice) Name() Name             { return h.name }
 func (*headSlice) NumDep() int              { return 1 }
 func (h *headSlice) Dep(i int) Dep          { return singleDep(i, h.Slice, false) }
-func (*headSlice) Combiner() *reflect.Value { return nil }
+func (*headSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 type headReader struct {
 	reader sliceio.Reader
@@ -961,7 +962,7 @@ func (*scanSlice) NumOut() int              { return 0 }
 func (*scanSlice) Out(c int) reflect.Type   { panic(c) }
 func (*scanSlice) NumDep() int              { return 1 }
 func (s *scanSlice) Dep(i int) Dep          { return singleDep(i, s.Slice, false) }
-func (*scanSlice) Combiner() *reflect.Value { return nil }
+func (*scanSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 type scanReader struct {
 	slice  scanSlice

--- a/slice.go
+++ b/slice.go
@@ -90,7 +90,7 @@ type Slice interface {
 
 	// Combiner is an optional function that is used to combine multiple
 	// values with the same key from the slice's output. No combination
-	// is performed if empty.
+	// is performed if Nil.
 	Combiner() slicefunc.Func
 
 	// Reader returns a Reader for a shard of this Slice. The reader

--- a/slicefunc/func.go
+++ b/slicefunc/func.go
@@ -1,0 +1,78 @@
+// Copyright 2019 GRAIL, Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+// Package slicefunc provides types and code to call user-defined functions with
+// Bigslice.
+package slicefunc
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/grailbio/bigslice/slicetype"
+	"github.com/grailbio/bigslice/typecheck"
+)
+
+// Nil is a nil Func.
+var Nil Func
+
+var typeOfContext = reflect.TypeOf((*context.Context)(nil)).Elem()
+
+// Func represents a user-defined function within Bigslice. Currently it's a
+// simple shim that's used to determine whether a context should be supplied to
+// the callee.
+//
+// TODO(marius): Evolve this abstraction over time to avoid the use of
+// reflection. For example, we can generate (via a template) code for
+// invocations on common types. Having this abstraction in place makes this
+// possible to do without changing any of the callers.
+//
+// TODO(marius): Another possibility is to exploit the fact that we have already
+// typechecked the data pipeline within Bigslice, and thus can avoid the
+// per-call typechecking overhead that is incurred by reflection. For example,
+// we could allow Funcs to mint a new re-usable call frame that we can write
+// values directly into. This might get us most of the former but with more
+// generality and arguably less complexity. We could even pre-generate generate
+// call frames for each row in a frame, since that is re-used also.
+//
+// TODO(marius): consider using this package to allow user-defined funcs to
+// return an error in the last argument.
+type Func struct {
+	// In and Out represent the slicetype of the function's input and output,
+	// respectively.
+	In, Out     slicetype.Type
+	fn          reflect.Value
+	contextFunc bool
+}
+
+// Of creates a Func from the provided function. Of panics if fn is not a
+// func.
+func Of(fn interface{}) Func {
+	in, out, ok := typecheck.Func(fn)
+	if !ok {
+		panic("slicefunc.New: invalid func")
+	}
+	v := reflect.ValueOf(fn)
+	t := v.Type()
+	context := t.NumIn() > 0 && t.In(0) == typeOfContext
+	return Func{in, out, v, context}
+}
+
+// Call invokes the function with the provided arguments, and returns the
+// reflected return values.
+//
+// TODO(marius): using reflect.Value here is not ideal for performance,
+// but there may be more holistic approaches (see above) since we're
+// (almost) always invoking functions from frames.
+func (f Func) Call(ctx context.Context, args []reflect.Value) []reflect.Value {
+	if f.contextFunc {
+		return f.fn.Call(append([]reflect.Value{reflect.ValueOf(ctx)}, args...))
+	}
+	return f.fn.Call(args)
+}
+
+// IsNil returns whether the Func f is nil.
+func (f Func) IsNil() bool {
+	return f.fn == reflect.Value{}
+}

--- a/slicefunc/func.go
+++ b/slicefunc/func.go
@@ -33,7 +33,7 @@ var typeOfContext = reflect.TypeOf((*context.Context)(nil)).Elem()
 // per-call typechecking overhead that is incurred by reflection. For example,
 // we could allow Funcs to mint a new re-usable call frame that we can write
 // values directly into. This might get us most of the former but with more
-// generality and arguably less complexity. We could even pre-generate generate
+// generality and arguably less complexity. We could even pre-generate
 // call frames for each row in a frame, since that is re-used also.
 //
 // TODO(marius): consider using this package to allow user-defined funcs to

--- a/slicefunc/func_test.go
+++ b/slicefunc/func_test.go
@@ -1,0 +1,35 @@
+// Copyright 2019 GRAIL, Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+package slicefunc
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestFunc(t *testing.T) {
+	ctx := context.Background()
+	f := Of(func(x, y int) int { return x + y })
+
+	rv := f.Call(ctx, []reflect.Value{reflect.ValueOf(1), reflect.ValueOf(2)})
+	if got, want := len(rv), 1; got != want {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	if got, want := rv[0].Int(), int64(3); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	f = Of(func(pctx context.Context, x, y int) bool {
+		return x+y == 3 && pctx == ctx
+	})
+	rv = f.Call(ctx, []reflect.Value{reflect.ValueOf(1), reflect.ValueOf(2)})
+	if got, want := len(rv), 1; got != want {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	if !rv[0].Bool() {
+		t.Error("!ok")
+	}
+}

--- a/sortio/sort_test.go
+++ b/sortio/sort_test.go
@@ -12,6 +12,7 @@ import (
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/grailbio/bigslice/frame"
+	"github.com/grailbio/bigslice/slicefunc"
 	"github.com/grailbio/bigslice/sliceio"
 	"github.com/grailbio/bigslice/slicetype"
 )
@@ -236,7 +237,7 @@ func TestReduceReader(t *testing.T) {
 	for i := range readers {
 		readers[i] = sliceio.FrameReader(f)
 	}
-	reducer := Reduce(f, "testreduce", readers, reflect.ValueOf(func(x, y int) int { return x + y }))
+	reducer := Reduce(f, "testreduce", readers, slicefunc.Of(func(x, y int) int { return x + y }))
 	var (
 		outIntsKey []int
 		outStrsKey []string

--- a/typecheck/func.go
+++ b/typecheck/func.go
@@ -5,10 +5,13 @@
 package typecheck
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/grailbio/bigslice/slicetype"
 )
+
+var typeOfContext = reflect.TypeOf((*context.Context)(nil)).Elem()
 
 type funcSliceType struct {
 	reflect.Type
@@ -18,6 +21,10 @@ func (funcSliceType) Prefix() int { return 1 }
 
 // Func deconstructs a function's argument and return types into
 // slicetypes. If x is not a function, Func returns false.
+//
+// If the type of the first argument to the provided function
+// is context.Context, then it is ignored: the returned type
+// contains only the remainder of the arguments.
 func Func(x interface{}) (arg, ret slicetype.Type, ok bool) {
 	t := reflect.TypeOf(x)
 	if t == nil {
@@ -27,8 +34,11 @@ func Func(x interface{}) (arg, ret slicetype.Type, ok bool) {
 		return nil, nil, false
 	}
 	in := make([]reflect.Type, t.NumIn())
-	for i := 0; i < t.NumIn(); i++ {
+	for i := range in {
 		in[i] = t.In(i)
+	}
+	if len(in) > 0 && in[0] == typeOfContext {
+		in = in[1:]
 	}
 	return slicetype.New(in...), funcSliceType{t}, true
 }

--- a/typecheck/func_test.go
+++ b/typecheck/func_test.go
@@ -5,6 +5,7 @@
 package typecheck
 
 import (
+	"context"
 	"testing"
 
 	"github.com/grailbio/bigslice/slicetype"
@@ -19,6 +20,19 @@ func TestFunc(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 	if got, want := ret, slicetype.New(typeOfString); !Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestFuncContext(t *testing.T) {
+	arg, ret, ok := Func(func(ctx context.Context, x int) bool { return false })
+	if !ok {
+		t.Fatal("!ok")
+	}
+	if got, want := arg, slicetype.New(typeOfInt); !Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := ret, slicetype.New(typeOfBool); !Equal(got, want) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 }

--- a/typecheck/typecheck_test.go
+++ b/typecheck/typecheck_test.go
@@ -14,6 +14,7 @@ import (
 var (
 	typeOfString = reflect.TypeOf("")
 	typeOfInt    = reflect.TypeOf(0)
+	typeOfBool   = reflect.TypeOf(false)
 )
 
 func TestEqual(t *testing.T) {


### PR DESCRIPTION

Package slicefunc abstracts user-provided funcs. We replace
occurences of user-provided functions with the new type
slicefunc.Func. slicefunc.Func manages whether to plumb a context
arguments to the function. (typecheck.Func is amended accordingly.)

Slicefunc can be used in the future to provide additional
functionality (e.g., allowing a user to return an error explicitly),
and also gives us an abstraction through which we may perform future
optimizations.

This is the first step towards #18.