### PR TITLE
propagate fatal gob errors

### DIFF
--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -465,6 +465,7 @@ type worker struct {
 	// CombinerStates and combiners are used to manage shared combine
 	// buffers.
 	combinerStates map[TaskName]combinerState
+	combinerErrors map[TaskName]error
 	combiners      map[TaskName][]chan *combiner
 
 	commitLimiter *limiter.Limiter
@@ -477,6 +478,7 @@ func (w *worker) Init(b *bigmachine.B) error {
 	w.slices = make(map[uint64]bigslice.Slice)
 	w.combiners = make(map[TaskName][]chan *combiner)
 	w.combinerStates = make(map[TaskName]combinerState)
+	w.combinerErrors = make(map[TaskName]error)
 	w.b = b
 	dir, err := ioutil.TempDir("", "bigslice")
 	if err != nil {
@@ -952,9 +954,13 @@ func (w *worker) runCombine(ctx context.Context, task *Task, taskStats *stats.Ma
 	}
 	w.mu.Lock()
 	switch w.combinerStates[combineKey] {
-	case combinerWriting, combinerCommitted, combinerError:
+	case combinerWriting, combinerCommitted:
 		w.mu.Unlock()
 		return fmt.Errorf("combine key %s already committed", combineKey)
+	case combinerError:
+		err := w.combinerErrors[combineKey]
+		w.mu.Unlock()
+		return maybeTaskFatalErr{err}
 	case combinerNone:
 		combiners := make([]chan *combiner, task.NumPartition)
 		for i := range combiners {
@@ -1091,7 +1097,7 @@ func (w *worker) CommitCombiner(ctx context.Context, key TaskName, _ *struct{}) 
 		case combinerCommitted:
 			return nil
 		case combinerError:
-			return errors.E("error while writing combiner")
+			return errors.E("error while writing combiner", w.combinerErrors[key])
 		case combinerIdle:
 			w.combinerStates[key] = combinerWriting
 			go w.writeCombiner(key)
@@ -1136,6 +1142,7 @@ func (w *worker) writeCombiner(key TaskName) {
 		w.combinerStates[key] = combinerCommitted
 	} else {
 		log.Error.Printf("failed to write combine buffer %s: %v", key, err)
+		w.combinerErrors[key] = err
 		w.combinerStates[key] = combinerError
 	}
 	w.cond.Broadcast()

--- a/slice_test.go
+++ b/slice_test.go
@@ -7,7 +7,6 @@ package bigslice_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"runtime"
@@ -19,6 +18,7 @@ import (
 
 	fuzz "github.com/google/gofuzz"
 	"github.com/grailbio/base/log"
+	"github.com/grailbio/base/errors"
 	"github.com/grailbio/bigmachine/rpc"
 	"github.com/grailbio/bigmachine/testsystem"
 	"github.com/grailbio/bigslice"
@@ -66,7 +66,27 @@ var executors = map[string]exec.Option{
 }
 
 func run(ctx context.Context, t *testing.T, slice bigslice.Slice) map[string]*sliceio.Scanner {
-	results := make(map[string]*sliceio.Scanner)
+	t.Helper()
+	scannerErrs := runError(ctx, t, slice)
+	scanners := make(map[string]*sliceio.Scanner, len(scannerErrs))
+	for name, scannerErr := range scannerErrs {
+		if err := scannerErr.Err; err != nil {
+			t.Errorf("executor %s error %v", name, err)
+		} else {
+			scanners[name] = scannerErr.Scanner
+		}
+	}
+	return scanners
+}
+
+type scannerErr struct {
+	*sliceio.Scanner
+	Err error
+}
+
+func runError(ctx context.Context, t *testing.T, slice bigslice.Slice) map[string]scannerErr {
+	t.Helper()
+	results := make(map[string]scannerErr)
 	fn := bigslice.Func(func() bigslice.Slice { return slice })
 
 	for name, opt := range executors {
@@ -77,11 +97,7 @@ func run(ctx context.Context, t *testing.T, slice bigslice.Slice) map[string]*sl
 		// TODO(marius): faster teardown in bigmachine so that we can call this here.
 		// defer sess.Shutdown()
 		res, err := sess.Run(ctx, fn)
-		if err != nil {
-			t.Errorf("executor %s error %v", name, err)
-			continue
-		}
-		results[name] = res.Scanner()
+		results[name] = scannerErr{res.Scanner(), err}
 	}
 	return results
 }
@@ -851,6 +867,38 @@ func TestPanic(t *testing.T) {
 		}
 		if msg := err.Error(); !strings.Contains(msg, "panic while evaluating slice") {
 			t.Errorf("wrong error message %q", msg)
+		}
+	}
+}
+
+func TestEncodingError(t *testing.T) {
+	type ungobable struct {
+		x int
+	}
+	slice := bigslice.Const(1, []int{1, 2, 3})
+	slice = bigslice.Map(slice, func(x int) (int, ungobable) { return x, ungobable{x} })
+	slice = bigslice.Reduce(slice, func(a, e ungobable) ungobable { return ungobable{a.x + e.x} })
+
+	scannerErrs := runError(context.Background(), t, slice)
+	for name, scannerErr := range scannerErrs {
+		// The local executor keeps things in memory by default.
+		// Note thaht while, currently the Bigmachine executors will by default
+		// run everything through gob, this is not at all a requirement. So this
+		// test may begin failing in the presence of future optimizatons.
+		if name == "Local" {
+			continue
+		}
+		err := scannerErr.Err
+		if err == nil {
+			t.Errorf("%s: expected error", name)
+			continue
+		}
+		expected := errors.E(errors.Remote, errors.Fatal)
+		if !errors.Match(expected, err) {
+			t.Errorf("error %s: expected Remote, Fatal", err)
+		}
+		if !strings.Contains(err.Error(), "gob: type bigslice_test.ungobable has no exported fields") {
+			t.Errorf("error %s: expected gob error", err)
 		}
 	}
 }

--- a/sliceio/codec.go
+++ b/sliceio/codec.go
@@ -13,6 +13,7 @@ import (
 	"hash/crc32"
 	"io"
 	"reflect"
+	"strings"
 	"unsafe"
 
 	"github.com/grailbio/base/errors"
@@ -98,6 +99,12 @@ func (e *Encoder) Encode(f frame.Frame) error {
 			err = e.enc.EncodeValue(f.Value(col))
 		}
 		if err != nil {
+			// Here we're encoding a user-defined type. We pessimistically
+			// attribute any errors that appear to come from gob as being
+			// related to the inability to encode this user-defined type.
+			if strings.HasPrefix(err.Error(), "gob: ") {
+				err = errors.E(errors.Fatal, err)
+			}
 			return err
 		}
 	}


### PR DESCRIPTION

This change marks as fatal and propagates errors that come from gob while
encoding user-defined. We also ensure that these are propagated in full fidelity
from failed combiner tasks.

This should help short-circuit retries on would-be fatal errors, and provide
much better reporting to the user of these.