### PR TITLE
Slice: add partitioner 

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -22,7 +22,7 @@ var _ slicecache.Cacheable = (*cacheSlice)(nil)
 
 func (c *cacheSlice) Name() Name                                             { return c.name }
 func (c *cacheSlice) NumDep() int                                            { return 1 }
-func (c *cacheSlice) Dep(i int) Dep                                          { return Dep{c.Slice, false, false} }
+func (c *cacheSlice) Dep(i int) Dep                                          { return Dep{c.Slice, false, nil, false} }
 func (*cacheSlice) Combiner() slicefunc.Func                                 { return slicefunc.Nil }
 func (c *cacheSlice) Reader(shard int, deps []sliceio.Reader) sliceio.Reader { return deps[0] }
 

--- a/cogroup.go
+++ b/cogroup.go
@@ -110,6 +110,7 @@ func (c *cogroupSlice) Prefix() int            { return c.prefix }
 func (c *cogroupSlice) NumDep() int            { return len(c.slices) }
 func (c *cogroupSlice) Dep(i int) Dep          { return Dep{c.slices[i], true, false} }
 func (*cogroupSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
+func (*cogroupSlice) Partitioner() Partitioner { return nil }
 
 type cogroupReader struct {
 	err error

--- a/cogroup.go
+++ b/cogroup.go
@@ -108,9 +108,8 @@ func (c *cogroupSlice) NumOut() int            { return len(c.out) }
 func (c *cogroupSlice) Out(i int) reflect.Type { return c.out[i] }
 func (c *cogroupSlice) Prefix() int            { return c.prefix }
 func (c *cogroupSlice) NumDep() int            { return len(c.slices) }
-func (c *cogroupSlice) Dep(i int) Dep          { return Dep{c.slices[i], true, false} }
+func (c *cogroupSlice) Dep(i int) Dep          { return Dep{c.slices[i], true, nil, false} }
 func (*cogroupSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
-func (*cogroupSlice) Partitioner() Partitioner { return nil }
 
 type cogroupReader struct {
 	err error

--- a/exec/compile.go
+++ b/exec/compile.go
@@ -245,7 +245,7 @@ func (c *compiler) compile(slice bigslice.Slice, part partitioner) (tasks []*Tas
 			combineKey = opName
 		}
 		depPart := partitioner{
-			slice.NumShard(), lastSlice.Partitioner(),
+			slice.NumShard(), dep.Partitioner,
 			lastSlice.Combiner(), combineKey,
 		}
 		depTasks, err := c.compile(dep.Slice, depPart)

--- a/exec/compile.go
+++ b/exec/compile.go
@@ -127,8 +127,9 @@ type compiler struct {
 // compilation so that tasks can be reused within the invocation.
 func (c *compiler) compile(slice bigslice.Slice, part partitioner) (tasks []*Task, err error) {
 	// We never reuse combiner tasks, as we currently don't have a way of
-	// identifying equivalent combiner functions.
-	if part.Combiner.IsNil() {
+	// identifying equivalent combiner functions. Ditto with custom
+	// partitioners.
+	if part.Combiner.IsNil() && part.partitioner == nil {
 		// TODO(jcharumilind): Repartition already-computed data instead of
 		// forcing recomputation of the slice if we get a different
 		// numPartition.

--- a/exec/local.go
+++ b/exec/local.go
@@ -154,6 +154,7 @@ func bufferOutput(ctx context.Context, task *Task, out sliceio.Reader) (buf task
 			err = errors.E(err, errors.Fatal)
 		}
 	}()
+	shards := make([]int, *defaultChunksize)
 	for {
 		if in.IsZero() {
 			in = frame.Make(task, *defaultChunksize, *defaultChunksize)
@@ -167,8 +168,9 @@ func bufferOutput(ctx context.Context, task *Task, out sliceio.Reader) (buf task
 		// elements in their respective partitions. In this case, we just
 		// maintain buffer slices of defaultChunksize each.
 		if task.NumPartition > 1 {
+			task.Partitioner(in, task.NumPartition, shards[:n])
 			for i := 0; i < n; i++ {
-				p := int(in.Hash(i)) % task.NumPartition
+				p := shards[i]
 				// If we don't yet have a buffer or the current one is at capacity,
 				// create a new one.
 				m := len(buf[p])

--- a/exec/task.go
+++ b/exec/task.go
@@ -230,6 +230,10 @@ type Task struct {
 	Do func([]sliceio.Reader) sliceio.Reader
 	// Deps are the task's dependencies. See TaskDep for details.
 	Deps []TaskDep
+
+	// Partitioner is used to partition the task's output. It will only
+	// be called when NumPartition > 1.
+	Partitioner bigslice.Partitioner
 	// NumPartition is the number of partitions that are output by this task.
 	// If NumPartition > 1, then the task must also define a partitioner.
 	NumPartition int

--- a/reduce.go
+++ b/reduce.go
@@ -66,7 +66,7 @@ type reduceSlice struct {
 
 func (r *reduceSlice) Name() Name               { return r.name }
 func (*reduceSlice) NumDep() int                { return 1 }
-func (r *reduceSlice) Dep(i int) Dep            { return Dep{r.Slice, true, true} }
+func (r *reduceSlice) Dep(i int) Dep            { return Dep{r.Slice, true, nil, true} }
 func (r *reduceSlice) Combiner() slicefunc.Func { return r.combiner }
 
 func (r *reduceSlice) Reader(shard int, deps []sliceio.Reader) sliceio.Reader {

--- a/reshard.go
+++ b/reshard.go
@@ -34,7 +34,7 @@ func Reshard(slice Slice, nshard int) Slice {
 func (r *reshardSlice) Name() Name             { return r.name }
 func (*reshardSlice) NumDep() int              { return 1 }
 func (r *reshardSlice) NumShard() int          { return r.nshard }
-func (r *reshardSlice) Dep(i int) Dep          { return Dep{r.Slice, true, false} }
+func (r *reshardSlice) Dep(i int) Dep          { return Dep{r.Slice, true, nil, false} }
 func (*reshardSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 func (r *reshardSlice) Reader(shard int, deps []sliceio.Reader) sliceio.Reader {

--- a/reshuffle.go
+++ b/reshuffle.go
@@ -33,7 +33,7 @@ func Reshuffle(slice Slice) Slice {
 
 func (r *reshuffleSlice) Name() Name             { return r.name }
 func (*reshuffleSlice) NumDep() int              { return 1 }
-func (r *reshuffleSlice) Dep(i int) Dep          { return Dep{r.Slice, true, false} }
+func (r *reshuffleSlice) Dep(i int) Dep          { return Dep{r.Slice, true, nil, false} }
 func (*reshuffleSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
 
 func (r *reshuffleSlice) Reader(shard int, deps []sliceio.Reader) sliceio.Reader {

--- a/slice.go
+++ b/slice.go
@@ -64,16 +64,15 @@ const (
 // A Partitioner is used to assign partitions to rows in a frame.
 type Partitioner func(frame frame.Frame, nshard int, shards []int)
 
-// A Slice is a shardable, ordered dataset. Each slice consists of
-// zero or more columns of data distributed over one or  more shards.
-// Slices may declare dependencies on other slices from which it is
-// computed. In order to compute a slice, its dependencies must first
-// be computed, and their resulting Readers are passed to a Slice's
-// Reader method.
+// A Slice is a shardable, ordered dataset. Each slice consists of zero or more
+// columns of data distributed over one or  more shards. Slices may declare
+// dependencies on other slices from which it is computed. In order to compute
+// a slice, its dependencies must first be computed, and their resulting
+// Readers are passed to a Slice's Reader method.
 //
-// Since Go does not support generic typing, Slice combinators
-// perform their own dynamic type checking. Schematically we write
-// the n-ary slice with types t1, t2, ..., tn as Slice<t1, t2, ..., tn>.
+// Since Go does not support generic typing, Slice combinators perform their
+// own dynamic type checking. Schematically we write the n-ary slice with types
+// t1, t2, ..., tn as Slice<t1, t2, ..., tn>.
 //
 // Types that implement the Slice interface must be comparable.
 type Slice interface {
@@ -93,15 +92,15 @@ type Slice interface {
 	// Dep returns the i'th dependency for this Slice.
 	Dep(i int) Dep
 
-	// Combiner is an optional function that is used to combine multiple
-	// values with the same key from the slice's output. No combination
-	// is performed if Nil.
+	// Combiner is an optional function that is used to combine multiple values
+	// with the same key from the slice's output. No combination is performed
+	// if Nil.
 	Combiner() slicefunc.Func
 
-	// Reader returns a Reader for a shard of this Slice. The reader
-	// itself computes the shard's values on demand. The caller must
-	// provide Readers for all of this shard's dependencies, constructed
-	// according to the dependency type (see Dep).
+	// Reader returns a Reader for a shard of this Slice. The reader itself
+	// computes the shard's values on demand. The caller must provide Readers
+	// for all of this shard's dependencies, constructed according to the
+	// dependency type (see Dep).
 	Reader(shard int, deps []sliceio.Reader) sliceio.Reader
 }
 


### PR DESCRIPTION
This change adds an explicit partitioner to interface Slice. This is
then used by the runtime to partition output instead of the (default)
hash partitioner.

This is the first step towards #17, putting the APIs in place to enable
custom partitioning functions provided by the user.
b9c0924