### PR TITLE
cmd/bigslice: set DefaultRegion and cleanup error message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,3 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 )
-
-replace github.com/grailbio/bigmachine => /data/forks/bigmachine

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ go 1.12
 require (
 	github.com/aws/aws-sdk-go v1.25.13
 	github.com/google/gofuzz v1.0.0
-	github.com/grailbio/base v0.0.5
+	github.com/grailbio/base v0.0.6
 	github.com/grailbio/bigmachine v0.5.5
 	github.com/grailbio/testutil v0.0.3
 	github.com/spaolacci/murmur3 v1.1.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 )
+
+replace github.com/grailbio/bigmachine => /data/forks/bigmachine

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/grailbio/base v0.0.1/go.mod h1:wVM2Cq2/HT0rt6WYGQhXJ3CCLkNnGjeAAOPHCZ2IsN0=
 github.com/grailbio/base v0.0.5 h1:9LoafGwmMR4QPEOZ5Kz0posu/pbGhDleT7Owqj8l7Yg=
 github.com/grailbio/base v0.0.5/go.mod h1:OFVz7zmqb1D+Jbew0B4DCIpl4ozzVFxf+JKQZBBIQzE=
+github.com/grailbio/base v0.0.6 h1:Hr1OHe16+sQEf4CytYlTu2bR+Sq5VENKA/sZoDBGo+k=
+github.com/grailbio/base v0.0.6/go.mod h1:OFVz7zmqb1D+Jbew0B4DCIpl4ozzVFxf+JKQZBBIQzE=
 github.com/grailbio/bigmachine v0.5.5 h1:uHdPrVTKw9BQmcfE70b7q126LJac8TiCnqOvS+UmvOo=
 github.com/grailbio/bigmachine v0.5.5/go.mod h1:8cYMHQBaSMyR9Gy9vh6YDE6uo+SgbEsnBXIGVp3gKGE=
 github.com/grailbio/v23/factories/grail v0.0.0-20190904050408-8a555d238e9a h1:kAl1x1ErQgs55bcm/WdoKCPny/kIF7COmC+UGQ9GKcM=


### PR DESCRIPTION
This PR makes use of the change made [in](https://github.com/grailbio/bigmachine/pull/29) to set a default AWS region if one is present in the bigmachine config. It also improves an error message.

Also, dependencies are updated for grailbio/base to v.0.0.6 and not .0.0.5