### PR TITLE
Fix cache panic when pipelined dependency tasks have dependencies

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -357,7 +357,7 @@ func runLocal(ctx context.Context, t *testing.T, slice bigslice.Slice) *sliceio.
 	defer sess.Shutdown()
 	res, err := sess.Run(ctx, fn)
 	if err != nil {
-		t.Fatalf("error running func:%v", err)
+		t.Fatalf("error running func: %v", err)
 	}
 	return res.Scanner()
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -20,12 +20,12 @@ import (
 )
 
 func TestCache(t *testing.T) {
-	makeSlice := func(N, Nshard int, dir string, computeAllowed bool) bigslice.Slice {
-		input := make([]int, N)
+	makeSlice := func(n, nShard int, dir string, computeAllowed bool) bigslice.Slice {
+		input := make([]int, n)
 		for i := range input {
 			input[i] = i
 		}
-		slice := bigslice.Const(Nshard, input)
+		slice := bigslice.Const(nShard, input)
 		slice = bigslice.Map(slice, func(i int) int {
 			if !computeAllowed {
 				panic("compute not allowed")
@@ -49,12 +49,12 @@ func TestCache(t *testing.T) {
 // empty dependencies given to tasks that expect non-empty dependencies).
 func TestCacheDeps(t *testing.T) {
 	exec.DoShuffleReaders = false
-	makeSlice := func(N, Nshard int, dir string, computeAllowed bool) bigslice.Slice {
-		input := make([]int, N)
+	makeSlice := func(n, nShard int, dir string, computeAllowed bool) bigslice.Slice {
+		input := make([]int, n)
 		for i := range input {
 			input[i] = i
 		}
-		slice := bigslice.Const(Nshard, input)
+		slice := bigslice.Const(nShard, input)
 		// This shuffle causes a break in the pipeline, so the pipelined task
 		// will have a dependency on the Const slice tasks. Caching should cause
 		// compilation/execution to eliminate these dependencies safely.
@@ -78,7 +78,7 @@ func TestCacheDeps(t *testing.T) {
 
 // runTestCache verifies that the caching in the slice returned by makeSlice
 // behaves as expected. See usage in TestCache.
-func runTestCache(t *testing.T, makeSlice func(N, Nshard int, dir string, computeAllowed bool) bigslice.Slice) {
+func runTestCache(t *testing.T, makeSlice func(n, nShard int, dir string, computeAllowed bool) bigslice.Slice) {
 	dir, cleanup := testutil.TempDir(t, "", "")
 	defer cleanup()
 	ctx := context.Background()

--- a/cache_test.go
+++ b/cache_test.go
@@ -87,10 +87,6 @@ func runTestCache(t *testing.T, makeSlice func(n, nShard int, dir string, comput
 		N      = 10000
 		Nshard = 10
 	)
-	input := make([]int, N)
-	for i := range input {
-		input[i] = i
-	}
 	slice := makeSlice(N, Nshard, dir, true)
 	if got, want := len(ls1(t, dir)), 0; got != want {
 		t.Errorf("got %v, want %v", got, want)

--- a/internal/slicecache/slicecache.go
+++ b/internal/slicecache/slicecache.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 
 	"github.com/grailbio/base/file"
+	"github.com/grailbio/base/log"
 	"github.com/grailbio/base/traverse"
 	"github.com/grailbio/bigslice/sliceio"
 )
@@ -63,14 +64,19 @@ func (c *ShardCache) RequireAllCached() {
 	}
 }
 
-// Reader returns a reader that uses the cache, or populates it.
-// reader should read computed data
-func (c *ShardCache) Reader(shard int, reader sliceio.Reader) sliceio.Reader {
+// WritethroughReader returns a reader that populates the cache. reader should
+// read computed data.
+func (c *ShardCache) WritethroughReader(shard int, reader sliceio.Reader) sliceio.Reader {
 	if c == nil {
 		return reader
 	}
-	if c.shardIsCached[shard] {
-		return newFileReader(c.path(shard))
-	}
 	return newWritethroughReader(reader, c.path(shard))
+}
+
+// CacheReader returns a reader that reads from the cache.
+func (c *ShardCache) CacheReader(shard int) sliceio.Reader {
+	if !c.shardIsCached[shard] {
+		log.Panicf("shard %d is not cached", shard)
+	}
+	return newFileReader(c.path(shard))
 }


### PR DESCRIPTION
If tasks compiled from a `Cache` slice are part of a pipeline of tasks that have dependencies, and the cache is populated, evaluating the pipelined task causes a panic.

For example, suppose you have a slice like this:
```go
slice := bigslice.Const(...)
slice = bigslice.Reshuffle(slice)
slice = bigslice.Cache(slice, ...)
```
Evaluating this slice with a populated cache will cause a panic, because the existing code eliminates the task dependencies, which in turn causes empty readers to be passed to `(*reshardSlice).Reader`, which panics.

To support testing of this scenario, we introduce `runLocal`, as we're not really testing the cache with multiple executors anyway, and multiple executors cause problems as they nondeterministically read from shuffle dependencies.