### PR TITLE
Implement Procs pragma

### DIFF
--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -242,8 +242,8 @@ func (b *bigmachineExecutor) Run(task *Task) {
 		cluster = int(task.Invocation.Index)
 	}
 	mgr := b.manager(cluster)
-	procs := 1
-	if task.Pragma.Exclusive() {
+	procs := task.Pragma.Procs()
+	if task.Pragma.Exclusive() || procs > mgr.machprocs {
 		procs = mgr.machprocs
 	}
 	var (

--- a/exec/bigmachine_test.go
+++ b/exec/bigmachine_test.go
@@ -257,7 +257,7 @@ func TestBigmachineExecutorProcs(t *testing.T) {
 	for _, task := range tasks[3:] {
 		go x.Run(task)
 		func() {
-			ctx, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
+			ctx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 			defer cancel()
 			state, err := task.WaitState(ctx, TaskRunning)
 			if ctx.Err() != nil {

--- a/exec/bigmachine_test.go
+++ b/exec/bigmachine_test.go
@@ -171,6 +171,129 @@ func TestBigmachineExecutorPanicCompile(t *testing.T) {
 	run(t, x, tasks, TaskErr)
 }
 
+// TestBigmachineExecutorProcs verifies that using the Procs pragma properly
+// affects machine/proc allocation.
+func TestBigmachineExecutorProcs(t *testing.T) {
+	// Set up the test with:
+	// - a slice with 8 tasks
+	// - Procs(2) so that two procs are allocated for each task
+	// - a system with 12 procs, 4 procs per machine
+	system := testsystem.New()
+	system.Machineprocs = 4
+	ctx, cancel := context.WithCancel(context.Background())
+	x := newBigmachineExecutor(system)
+	shutdown := x.Start(&Session{
+		Context: ctx,
+		p:       12, // 3 machines
+		maxLoad: 1,
+	})
+	defer shutdown()
+	defer cancel()
+
+	// We use the wait group to block completion of tasks, controlling execution
+	// for our test.
+	var wg sync.WaitGroup
+	fn := bigslice.Func(func() bigslice.Slice {
+		is := make([]int, 100)
+		for i := range is {
+			is[i] = i
+		}
+		slice := bigslice.ReaderFunc(8, func(shard int, x *int, xs []int) (int, error) {
+			wg.Wait()
+			const N = 10
+			var i int
+			for *x < N && i < len(xs) {
+				xs[i] = (shard * N) + *x
+				i++
+				*x++
+			}
+			if *x == N {
+				return i, sliceio.EOF
+			}
+			return i, nil
+		})
+		// Add an identity mapping to exercise pipelining.
+		slice = bigslice.Map(slice, func(i int) int {
+			return i
+		}, bigslice.Procs(2))
+		return slice
+	})
+	inv := fn.Invocation("<test>")
+	slice := inv.Invoke()
+	tasks, err := compile(slice, inv, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Verify that there is one task per shard.
+	if got, want := len(tasks), 8; got != want {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	// Verify that the proc need is propagated through the pipeline.
+	for _, task := range tasks {
+		if got, want := task.Pragma.Procs(), 2; got != want {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+	// Don't let anything run to completion yet.
+	wg.Add(1)
+	// Run three tasks (needing 6 procs), and verify that two machines have been
+	// started on which to run them.
+	for _, task := range tasks[:3] {
+		go x.Run(task)
+		state, err := task.WaitState(ctx, TaskRunning)
+		if err != nil || state != TaskRunning {
+			t.Fatal(state, err)
+		}
+	}
+	if got, want := system.N(), 2; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	// Run the rest of the tasks, and verify that the remaining machines have
+	// been started on which to run them.
+	//
+	// Note: this is racy, as we don't have a way of knowing that the executor
+	// has blocked because it cannot acquire a machine on which to run a task.
+	// If this is a problem, we'll need a better solution.
+	for _, task := range tasks[3:] {
+		go x.Run(task)
+		func() {
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Millisecond)
+			defer cancel()
+			state, err := task.WaitState(ctx, TaskRunning)
+			if ctx.Err() != nil {
+				// We expect some tasks to not reach TaskRunning, as there are
+				// not enough procs to service them.
+				return
+			}
+			if err != nil || state != TaskRunning {
+				t.Fatal(state, err)
+			}
+		}()
+	}
+	if got, want := system.N(), 3; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	// Only 6 of the 8 shards should be running at this point, occupying all
+	// procs.
+	var running int
+	for _, task := range tasks {
+		if task.State() == TaskRunning {
+			running++
+		}
+	}
+	if got, want := running, 6; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	// Verify that everything runs to completion.
+	wg.Done()
+	for _, task := range tasks {
+		state, err := task.WaitState(ctx, TaskOk)
+		if err != nil || state != TaskOk {
+			t.Fatal(state, err)
+		}
+	}
+}
+
 func TestBigmachineExecutorPanicRun(t *testing.T) {
 	x, stop := bigmachineTestExecutor(1)
 	defer stop()

--- a/exec/bigmachine_test.go
+++ b/exec/bigmachine_test.go
@@ -211,7 +211,7 @@ func TestBigmachineExecutorProcs(t *testing.T) {
 				return i, sliceio.EOF
 			}
 			return i, nil
-		})
+		}, bigslice.Procs(1)) // Exercise Procs composition.
 		// Add an identity mapping to exercise pipelining.
 		slice = bigslice.Map(slice, func(i int) int {
 			return i

--- a/slice.go
+++ b/slice.go
@@ -122,7 +122,8 @@ type Pragma interface {
 // Pragmas composes multiple underlying Pragmas.
 type Pragmas []Pragma
 
-// Procs implements Pragma.
+// Procs implements Pragma. If multiple tasks with Procs pragmas are pipelined,
+// we allocate the maximum to the composed pipeline.
 func (p Pragmas) Procs() int {
 	need := 1
 	for _, q := range p {

--- a/slice.go
+++ b/slice.go
@@ -107,6 +107,10 @@ type Slice interface {
 // Pragma comprises runtime directives used during bigslice
 // execution.
 type Pragma interface {
+	// Procs returns the number of procs a slice task needs to run. It is
+	// superceded by Exclusive and clamped to the maximum number of procs per
+	// machine.
+	Procs() int
 	// Exclusive indicates that a slice task should be given
 	// exclusive access to the underlying machine.
 	Exclusive() bool
@@ -117,6 +121,18 @@ type Pragma interface {
 
 // Pragmas composes multiple underlying Pragmas.
 type Pragmas []Pragma
+
+// Procs implements Pragma.
+func (p Pragmas) Procs() int {
+	need := 1
+	for _, q := range p {
+		n := q.Procs()
+		if n > need {
+			need = n
+		}
+	}
+	return need
+}
 
 // Exclusive implements Pragma.
 func (p Pragmas) Exclusive() bool {
@@ -140,16 +156,18 @@ func (p Pragmas) Materialize() bool {
 
 type exclusive struct{}
 
+func (exclusive) Procs() int        { return 1 }
 func (exclusive) Exclusive() bool   { return true }
 func (exclusive) Materialize() bool { return false }
 
-// Exclusive is a Pragma that indicates the slice task
-// should be given exclusive access to the machine
-// that runs it.
+// Exclusive is a Pragma that indicates the slice task should be given
+// exclusive access to the machine that runs it. Exclusive takes precedence
+// over Procs.
 var Exclusive Pragma = exclusive{}
 
 type materialize struct{}
 
+func (materialize) Procs() int        { return 1 }
 func (materialize) Exclusive() bool   { return false }
 func (materialize) Materialize() bool { return true }
 
@@ -164,6 +182,21 @@ func (materialize) Materialize() bool { return true }
 // TODO(jcharumilind): Consider doing this automatically for slices on which
 // multiple slices depend.
 var ExperimentalMaterialize Pragma = materialize{}
+
+type procs struct {
+	n int
+}
+
+func (p procs) Procs() int      { return p.n }
+func (procs) Exclusive() bool   { return false }
+func (procs) Materialize() bool { return false }
+
+// Procs returns a pragma that sets the number of procs a slice task needs to
+// run to n. It is superceded by Exclusive and clamped to the maximum number of
+// procs per machine.
+func Procs(n int) Pragma {
+	return procs{n: n}
+}
 
 type constSlice struct {
 	name Name


### PR DESCRIPTION
Implement the Procs pragma, which allows users to specify the number of procs each shard task of a slice needs to run.  This is useful if slice computations have internal parallelism.