### PR TITLE
Make compilation stable w.r.t. cache state

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -15,7 +15,7 @@ import (
 type cacheSlice struct {
 	name Name
 	Slice
-	cache *slicecache.ShardCache
+	cache *slicecache.FileShardCache
 }
 
 var _ slicecache.Cacheable = (*cacheSlice)(nil)
@@ -26,7 +26,7 @@ func (c *cacheSlice) Dep(i int) Dep                                          { r
 func (*cacheSlice) Combiner() slicefunc.Func                                 { return slicefunc.Nil }
 func (c *cacheSlice) Reader(shard int, deps []sliceio.Reader) sliceio.Reader { return deps[0] }
 
-func (c *cacheSlice) Cache() *slicecache.ShardCache { return c.cache }
+func (c *cacheSlice) Cache() slicecache.ShardCache { return c.cache }
 
 // Cache caches the output of a slice to the given file prefix.
 // Cached data are stored as "prefix-nnnn-of-mmmm" for shards nnnn of
@@ -42,12 +42,12 @@ func (c *cacheSlice) Cache() *slicecache.ShardCache { return c.cache }
 // Cache uses GRAIL's file library, so prefix may refer to URLs to a
 // distributed object store such as S3.
 func Cache(ctx context.Context, slice Slice, prefix string) (Slice, error) {
-	shardCache, err := slicecache.NewShardCache(ctx, prefix, slice.NumShard())
+	shardCache, err := slicecache.NewFileShardCache(ctx, prefix, slice.NumShard())
 	if err != nil {
 		return nil, err
 	}
 	shardCache.RequireAllCached()
-	return &cacheSlice{makeName("cache"), slice, shardCache}, nil
+	return &cacheSlice{MakeName("cache"), slice, shardCache}, nil
 }
 
 // CachePartial caches the output of the slice to the given file
@@ -63,9 +63,9 @@ func Cache(ctx context.Context, slice Slice, prefix string) (Slice, error) {
 //
 // As with Cache, the user must guarantee cache consistency.
 func CachePartial(ctx context.Context, slice Slice, prefix string) (Slice, error) {
-	shardCache, err := slicecache.NewShardCache(ctx, prefix, slice.NumShard())
+	shardCache, err := slicecache.NewFileShardCache(ctx, prefix, slice.NumShard())
 	if err != nil {
 		return nil, err
 	}
-	return &cacheSlice{makeName("cachepartial"), slice, shardCache}, nil
+	return &cacheSlice{MakeName("cachepartial"), slice, shardCache}, nil
 }

--- a/cogroup.go
+++ b/cogroup.go
@@ -93,7 +93,7 @@ func Cogroup(slices ...Slice) Slice {
 	}
 
 	return &cogroupSlice{
-		name:     makeName("cogroup"),
+		name:     MakeName("cogroup"),
 		numShard: numShard,
 		slices:   slices,
 		out:      out,

--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -97,6 +97,10 @@ type bigmachineExecutor struct {
 	invocations    map[uint64]bigslice.Invocation
 	invocationDeps map[uint64]map[uint64]bool
 
+	// compileEnvs maintains the compilation environment used to compile tasks
+	// (for a particular invocation index).
+	compileEnvs map[uint64]CompileEnv
+
 	// Worker is the (configured) worker service to instantiate on
 	// allocated machines.
 	worker *worker
@@ -132,6 +136,7 @@ func (b *bigmachineExecutor) Start(sess *Session) (shutdown func()) {
 	}
 	b.invocations = make(map[uint64]bigslice.Invocation)
 	b.invocationDeps = make(map[uint64]map[uint64]bool)
+	b.compileEnvs = make(map[uint64]CompileEnv)
 	b.worker = &worker{
 		MachineCombiners: sess.machineCombiners,
 	}
@@ -160,7 +165,7 @@ func (b *bigmachineExecutor) manager(i int) *machineManager {
 
 type invocationRef struct{ Index uint64 }
 
-func (b *bigmachineExecutor) compile(ctx context.Context, m *sliceMachine, inv bigslice.Invocation) error {
+func (b *bigmachineExecutor) compile(ctx context.Context, m *sliceMachine, inv bigslice.Invocation, env CompileEnv) error {
 	// Substitute Result arguments for an invocation ref and record the
 	// dependency.
 	b.mu.Lock()
@@ -180,6 +185,7 @@ func (b *bigmachineExecutor) compile(ctx context.Context, m *sliceMachine, inv b
 		b.invocationDeps[inv.Index][result.inv.Index] = true
 	}
 	b.invocations[inv.Index] = inv
+	b.compileEnvs[inv.Index] = env
 
 	// Now traverse the invocation graph bottom-up, making sure
 	// everything on the machine is compiled. We produce a valid order,
@@ -203,6 +209,7 @@ func (b *bigmachineExecutor) compile(ctx context.Context, m *sliceMachine, inv b
 	for i := len(invocations) - 1; i >= 0; i-- {
 		err := m.Compiles.Do(invocations[i].Index, func() error {
 			inv := invocations[i]
+			env := b.compileEnvs[inv.Index]
 			// Flatten these into lists so that we don't capture further
 			// structure by JSON encoding down the line. We also truncate them
 			// so that, e.g., huge lists of arguments don't make it into the trace.
@@ -211,7 +218,8 @@ func (b *bigmachineExecutor) compile(ctx context.Context, m *sliceMachine, inv b
 				args[i] = truncatef(inv.Args[i])
 			}
 			b.sess.tracer.Event(m, inv, "B", "location", inv.Location, "args", args)
-			err := m.RetryCall(ctx, "Worker.Compile", inv, nil)
+			req := compileRequest{inv, env}
+			err := m.RetryCall(ctx, "Worker.Compile", req, nil)
 			if err != nil {
 				b.sess.tracer.Event(m, inv, "E", "error", err)
 			} else {
@@ -270,7 +278,7 @@ func (b *bigmachineExecutor) Run(task *Task) {
 	// machine.
 compile:
 	for {
-		err := b.compile(ctx, m, task.Invocation)
+		err := b.compile(ctx, m, task.Invocation, task.CompileEnv)
 		switch {
 		case err == nil:
 			break compile
@@ -508,33 +516,38 @@ func (w *worker) FuncLocations(ctx context.Context, _ struct{}, locs *[]string) 
 	return nil
 }
 
+type compileRequest struct {
+	Inv bigslice.Invocation
+	Env CompileEnv
+}
+
 // Compile compiles an invocation on the worker and stores the
 // resulting tasks. Compile is idempotent: it will compile each
 // invocation at most once.
-func (w *worker) Compile(ctx context.Context, inv bigslice.Invocation, _ *struct{}) (err error) {
+func (w *worker) Compile(ctx context.Context, req compileRequest, _ *struct{}) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("invocation panic! %v", e)
 			err = errors.E(errors.Fatal, err)
 		}
 	}()
-	return w.compiles.Do(inv.Index, func() error {
+	return w.compiles.Do(req.Inv.Index, func() error {
 		// Substitute invocation refs for the results of the invocation.
 		// The executor must ensure that all references have been compiled.
-		for i, arg := range inv.Args {
+		for i, arg := range req.Inv.Args {
 			ref, ok := arg.(invocationRef)
 			if !ok {
 				continue
 			}
 			w.mu.Lock()
-			inv.Args[i], ok = w.slices[ref.Index]
+			req.Inv.Args[i], ok = w.slices[ref.Index]
 			w.mu.Unlock()
 			if !ok {
 				return fmt.Errorf("worker.Compile: invalid invocation reference %x", ref.Index)
 			}
 		}
-		slice := inv.Invoke()
-		tasks, err := compile(slice, inv, w.MachineCombiners)
+		slice := req.Inv.Invoke()
+		tasks, err := compile(req.Env, slice, req.Inv, w.MachineCombiners)
 		if err != nil {
 			return err
 		}
@@ -551,9 +564,9 @@ func (w *worker) Compile(ctx context.Context, inv bigslice.Invocation, _ *struct
 			namedStats[task.Name] = stats.NewMap()
 		}
 		w.mu.Lock()
-		w.tasks[inv.Index] = named
-		w.taskStats[inv.Index] = namedStats
-		w.slices[inv.Index] = &Result{Slice: slice, tasks: tasks}
+		w.tasks[req.Inv.Index] = named
+		w.taskStats[req.Inv.Index] = namedStats
+		w.slices[req.Inv.Index] = &Result{Slice: slice, tasks: tasks}
 		w.mu.Unlock()
 		return nil
 	})

--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -195,11 +195,13 @@ func (b *bigmachineExecutor) compile(ctx context.Context, m *sliceMachine, inv b
 	var (
 		todo        = []uint64{inv.Index}
 		invocations []bigslice.Invocation
+		compileEnvs []CompileEnv
 	)
 	for len(todo) > 0 {
 		var i uint64
 		i, todo = todo[0], todo[1:]
 		invocations = append(invocations, b.invocations[i])
+		compileEnvs = append(compileEnvs, b.compileEnvs[i])
 		for j := range b.invocationDeps[i] {
 			todo = append(todo, j)
 		}
@@ -209,7 +211,7 @@ func (b *bigmachineExecutor) compile(ctx context.Context, m *sliceMachine, inv b
 	for i := len(invocations) - 1; i >= 0; i-- {
 		err := m.Compiles.Do(invocations[i].Index, func() error {
 			inv := invocations[i]
-			env := b.compileEnvs[inv.Index]
+			env := compileEnvs[i]
 			// Flatten these into lists so that we don't capture further
 			// structure by JSON encoding down the line. We also truncate them
 			// so that, e.g., huge lists of arguments don't make it into the trace.

--- a/exec/bigmachine_test.go
+++ b/exec/bigmachine_test.go
@@ -85,7 +85,7 @@ func TestBigmachineExecutorExclusive(t *testing.T) {
 			maxIndex = ix
 		}
 		slice := inv.Invoke()
-		tasks, err := compile(slice, inv, false)
+		tasks, err := compile(makeCompileEnv(), slice, inv, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -122,7 +122,7 @@ func TestBigmachineExecutorTaskExclusive(t *testing.T) {
 	})
 	inv := fn.Invocation("<test>")
 	slice := inv.Invoke()
-	tasks, err := compile(slice, inv, false)
+	tasks, err := compile(makeCompileEnv(), slice, inv, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -476,7 +476,7 @@ func compileFunc(f func() bigslice.Slice) ([]*Task, bigslice.Slice, bigslice.Inv
 	fn := bigslice.Func(f)
 	inv := fn.Invocation("")
 	slice := inv.Invoke()
-	tasks, err := compile(slice, inv, false)
+	tasks, err := compile(makeCompileEnv(), slice, inv, false)
 	if err != nil {
 		panic(err)
 	}
@@ -487,7 +487,7 @@ func compileFuncExclusive(f func() bigslice.Slice) ([]*Task, bigslice.Slice, big
 	fn := bigslice.Func(f).Exclusive()
 	inv := fn.Invocation("")
 	slice := inv.Invoke()
-	tasks, err := compile(slice, inv, false)
+	tasks, err := compile(makeCompileEnv(), slice, inv, false)
 	if err != nil {
 		panic(err)
 	}

--- a/exec/bigmachine_test.go
+++ b/exec/bigmachine_test.go
@@ -220,7 +220,7 @@ func TestBigmachineExecutorProcs(t *testing.T) {
 	})
 	inv := fn.Invocation("<test>")
 	slice := inv.Invoke()
-	tasks, err := compile(slice, inv, false)
+	tasks, err := compile(makeCompileEnv(), slice, inv, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/exec/compile.go
+++ b/exec/compile.go
@@ -320,9 +320,9 @@ func (c *compiler) compile(slice bigslice.Slice, part partitioner) (tasks []*Tas
 	// Use cache when configured.
 	for i := len(slices) - 1; i >= 0; i-- {
 		var (
-			pprofLabel                       = fmt.Sprintf("%s(%s)", slices[i].Name(), c.inv.Location)
-			reader                           = slices[i].Reader
-			shardCache slicecache.ShardCache = slicecache.Empty
+			pprofLabel = fmt.Sprintf("%s(%s)", slices[i].Name(), c.inv.Location)
+			reader     = slices[i].Reader
+			shardCache = slicecache.Empty
 		)
 		if c, ok := bigslice.Unwrap(slices[i]).(slicecache.Cacheable); ok {
 			shardCache = c.Cache()

--- a/exec/compile.go
+++ b/exec/compile.go
@@ -123,7 +123,7 @@ func compile(env CompileEnv, slice bigslice.Slice, inv bigslice.Invocation, mach
 	return
 }
 
-// compileEnv is the environment for compilation. This environment should
+// CompileEnv is the environment for compilation. This environment should
 // capture all external state that can affect compilation of an invocation. It
 // is shared across compilations of the same invocation (e.g. on worker nodes)
 // to guarantee consistent compilation results. This is a requirement of

--- a/exec/compile_test.go
+++ b/exec/compile_test.go
@@ -6,13 +6,13 @@ package exec
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"sort"
 	"strings"
 	"testing"
 
-	"context"
 	"github.com/grailbio/bigslice"
 	"github.com/grailbio/bigslice/frame"
 	"github.com/grailbio/bigslice/internal/slicecache"

--- a/exec/compile_test.go
+++ b/exec/compile_test.go
@@ -391,9 +391,16 @@ type fakeCacheSlice struct {
 	cache slicecache.ShardCache
 }
 
-func (c *fakeCacheSlice) Name() bigslice.Name                                    { return c.name }
-func (c *fakeCacheSlice) NumDep() int                                            { return 1 }
-func (c *fakeCacheSlice) Dep(i int) bigslice.Dep                                 { return bigslice.Dep{c.Slice, false, nil, false} }
+func (c *fakeCacheSlice) Name() bigslice.Name { return c.name }
+func (c *fakeCacheSlice) NumDep() int         { return 1 }
+func (c *fakeCacheSlice) Dep(i int) bigslice.Dep {
+	return bigslice.Dep{
+		Slice:       c.Slice,
+		Shuffle:     false,
+		Partitioner: nil,
+		Expand:      false,
+	}
+}
 func (*fakeCacheSlice) Combiner() slicefunc.Func                                 { return slicefunc.Nil }
 func (c *fakeCacheSlice) Reader(shard int, deps []sliceio.Reader) sliceio.Reader { return deps[0] }
 func (c *fakeCacheSlice) Cache() slicecache.ShardCache                           { return c.cache }

--- a/exec/session.go
+++ b/exec/session.go
@@ -239,11 +239,13 @@ func (s *Session) run(ctx context.Context, calldepth int, funcv *bigslice.FuncVa
 		defer statusMu.Unlock()
 		inv = funcv.Invocation(location, args...)
 		slice = inv.Invoke()
+		env := makeCompileEnv()
 		var err error
-		tasks, err = compile(slice, inv, s.machineCombiners)
+		tasks, err = compile(env, slice, inv, s.machineCombiners)
 		if err != nil {
 			return err
 		}
+		env.Freeze()
 		// TODO(marius): give a way to provide names for these groups
 		if s.status != nil {
 			// Make the slice status group come before the more granular task

--- a/exec/session.go
+++ b/exec/session.go
@@ -245,6 +245,8 @@ func (s *Session) run(ctx context.Context, calldepth int, funcv *bigslice.FuncVa
 		if err != nil {
 			return err
 		}
+		// Freeze the environment to ensure that compilations are consistent
+		// (e.g. across workers).
 		env.Freeze()
 		// TODO(marius): give a way to provide names for these groups
 		if s.status != nil {

--- a/exec/task.go
+++ b/exec/task.go
@@ -218,6 +218,9 @@ func (s *TaskSubscriber) Tasks() []*Task {
 // conditional variable to coordinate runtime state changes.
 type Task struct {
 	slicetype.Type
+	// CompileEnv is the compilation environment used/constructed for
+	// compilation of this task.
+	CompileEnv CompileEnv
 	// Invocation is the task's invocation, i.e. the Func invocation
 	// from which this task was compiled.
 	Invocation bigslice.Invocation

--- a/internal/slicecache/slicecache.go
+++ b/internal/slicecache/slicecache.go
@@ -23,6 +23,7 @@ type ShardCache interface {
 	CacheReader(shard int) sliceio.Reader
 }
 
+// Empty is an empty cache.
 var Empty = empty{}
 
 type empty struct{}

--- a/internal/slicecache/slicecache.go
+++ b/internal/slicecache/slicecache.go
@@ -13,12 +13,29 @@ import (
 
 // Cacheable indicates a slice's data should be cached.
 type Cacheable interface {
-	Cache() *ShardCache
+	Cache() ShardCache
 }
 
 // ShardCache accesses cached data for a slice's shards.
-// A nil *ShardCache has no cached data.
-type ShardCache struct {
+type ShardCache interface {
+	IsCached(shard int) bool
+	WritethroughReader(shard int, reader sliceio.Reader) sliceio.Reader
+	CacheReader(shard int) sliceio.Reader
+}
+
+var Empty = empty{}
+
+type empty struct{}
+
+func (empty) IsCached(shard int) bool { return false }
+func (empty) WritethroughReader(shard int, reader sliceio.Reader) sliceio.Reader {
+	return reader
+}
+func (empty) CacheReader(shard int) sliceio.Reader { panic("always empty") }
+
+// FileShardCache is a ShardCache backed by files. A nil *FileShardCache has no
+// cached data.
+type FileShardCache struct {
 	prefix        string
 	numShards     int
 	shardIsCached []bool
@@ -26,11 +43,14 @@ type ShardCache struct {
 
 // NewShardCache constructs a ShardCache. It does O(numShards) parallelized
 // file operations to look up what's present in the cache.
-func NewShardCache(ctx context.Context, prefix string, numShards int) (*ShardCache, error) {
+func NewFileShardCache(ctx context.Context, prefix string, numShards int) (*FileShardCache, error) {
 	if prefix == "" {
-		return &ShardCache{}, nil
+		return &FileShardCache{}, nil
 	}
-	c := ShardCache{prefix, numShards, make([]bool, numShards)}
+	// TODO(jcharumilind): Make this initialization more lazy. This is generally
+	// called within Funcs, but its result is generally ignored on workers to
+	// ensure a consistent view of the cache for consistent compilation.
+	c := FileShardCache{prefix, numShards, make([]bool, numShards)}
 	_ = traverse.Limit(10*runtime.NumCPU()).Each(numShards, func(shard int) error {
 		_, err := file.Stat(ctx, c.path(shard))
 		c.shardIsCached[shard] = err == nil // treat lookup errors as cache misses
@@ -39,18 +59,18 @@ func NewShardCache(ctx context.Context, prefix string, numShards int) (*ShardCac
 	return &c, nil
 }
 
-func (c *ShardCache) path(shard int) string {
+func (c *FileShardCache) path(shard int) string {
 	return fmt.Sprintf("%s-%04d-of-%04d", c.prefix, shard, c.numShards)
 }
 
-func (c *ShardCache) IsCached(shard int) bool {
+func (c *FileShardCache) IsCached(shard int) bool {
 	if c == nil {
 		return false
 	}
 	return c.shardIsCached[shard]
 }
 
-func (c *ShardCache) RequireAllCached() {
+func (c *FileShardCache) RequireAllCached() {
 	if c == nil {
 		return
 	}
@@ -66,7 +86,7 @@ func (c *ShardCache) RequireAllCached() {
 
 // WritethroughReader returns a reader that populates the cache. reader should
 // read computed data.
-func (c *ShardCache) WritethroughReader(shard int, reader sliceio.Reader) sliceio.Reader {
+func (c *FileShardCache) WritethroughReader(shard int, reader sliceio.Reader) sliceio.Reader {
 	if c == nil {
 		return reader
 	}
@@ -74,7 +94,7 @@ func (c *ShardCache) WritethroughReader(shard int, reader sliceio.Reader) slicei
 }
 
 // CacheReader returns a reader that reads from the cache.
-func (c *ShardCache) CacheReader(shard int) sliceio.Reader {
+func (c *FileShardCache) CacheReader(shard int) sliceio.Reader {
 	if !c.shardIsCached[shard] {
 		log.Panicf("shard %d is not cached", shard)
 	}

--- a/internal/slicecache/slicecache.go
+++ b/internal/slicecache/slicecache.go
@@ -24,7 +24,7 @@ type ShardCache interface {
 }
 
 // Empty is an empty cache.
-var Empty = empty{}
+var Empty ShardCache = empty{}
 
 type empty struct{}
 

--- a/name_test.go
+++ b/name_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func sliceOperation(helper bool) Name {
-	return makeName("test") // line 16
+	return MakeName("test") // line 16
 }
 
 func callSliceOp(helper bool) Name {

--- a/reduce.go
+++ b/reduce.go
@@ -54,7 +54,7 @@ func Reduce(slice Slice, reduce interface{}) Slice {
 	if arg.NumOut() != 2 || arg.Out(0) != outputType || arg.Out(1) != outputType || ret.NumOut() != 1 || ret.Out(0) != outputType {
 		typecheck.Panicf(1, "reduce: invalid reduce function %T, expected func(%s, %s) %s", reduce, outputType, outputType, outputType)
 	}
-	return &reduceSlice{slice, makeName("reduce"), slicefunc.Of(reduce)}
+	return &reduceSlice{slice, MakeName("reduce"), slicefunc.Of(reduce)}
 }
 
 // ReduceSlice implements "post shuffle" combining merge sort.

--- a/reshard.go
+++ b/reshard.go
@@ -28,7 +28,7 @@ func Reshard(slice Slice, nshard int) Slice {
 	if slice.NumShard() == nshard {
 		return slice
 	}
-	return &reshardSlice{makeName("reshard"), nshard, slice}
+	return &reshardSlice{MakeName("reshard"), nshard, slice}
 }
 
 func (r *reshardSlice) Name() Name             { return r.name }

--- a/reshuffle.go
+++ b/reshuffle.go
@@ -38,7 +38,7 @@ func Reshuffle(slice Slice) Slice {
 	if err := canMakeCombiningFrame(slice); err != nil {
 		typecheck.Panic(1, err.Error())
 	}
-	return &reshuffleSlice{makeName("reshuffle"), nil, slice}
+	return &reshuffleSlice{MakeName("reshuffle"), nil, slice}
 }
 
 // Repartition (re-)partitions the slice according to the provided function
@@ -73,7 +73,7 @@ func Repartition(slice Slice, fn interface{}) Slice {
 			shards[i] = int(result[0].Int())
 		}
 	}
-	return &reshuffleSlice{makeName("repartition"), part, slice}
+	return &reshuffleSlice{MakeName("repartition"), part, slice}
 }
 
 func (r *reshuffleSlice) Name() Name             { return r.name }

--- a/slice.go
+++ b/slice.go
@@ -180,7 +180,7 @@ func Const(nshard int, columns ...interface{}) Slice {
 		typecheck.Panic(1, "const: must have at least one column")
 	}
 	s := new(constSlice)
-	s.name = makeName("const")
+	s.name = MakeName("const")
 	s.nshard = nshard
 	if s.nshard < 1 {
 		typecheck.Panic(1, "const: shard must be >= 1")
@@ -277,7 +277,7 @@ type readerFuncSlice struct {
 // reader to maintain local state across the read of a whole shard.
 func ReaderFunc(nshard int, read interface{}, prags ...Pragma) Slice {
 	s := new(readerFuncSlice)
-	s.name = makeName("reader")
+	s.name = MakeName("reader")
 	s.nshard = nshard
 	arg, ret, ok := typecheck.Func(read)
 	if !ok || arg.NumOut() < 3 || arg.Out(0).Kind() != reflect.Int {
@@ -395,7 +395,7 @@ type writerFuncSlice struct {
 // across the write of the whole shard.
 func WriterFunc(slice Slice, write interface{}) Slice {
 	s := new(writerFuncSlice)
-	s.name = makeName("writer")
+	s.name = MakeName("writer")
 	s.Slice = slice
 
 	// Our error messages for wrongly-typed write functions include a
@@ -519,7 +519,7 @@ type mapSlice struct {
 //	Map(Slice<t1, t2, ..., tn>, func(v1 t1, v2 t2, ..., vn tn) (r1, r2, ..., rn)) Slice<r1, r2, ..., rn>
 func Map(slice Slice, fn interface{}, prags ...Pragma) Slice {
 	m := new(mapSlice)
-	m.name = makeName("map")
+	m.name = MakeName("map")
 	m.Slice = slice
 	arg, ret, ok := typecheck.Func(fn)
 	if !ok {
@@ -611,7 +611,7 @@ type filterSlice struct {
 //	Filter(Slice<t1, t2, ..., tn>, func(t1, t2, ..., tn) bool) Slice<t1, t2, ..., tn>
 func Filter(slice Slice, pred interface{}, prags ...Pragma) Slice {
 	f := new(filterSlice)
-	f.name = makeName("filter")
+	f.name = MakeName("filter")
 	f.Slice = slice
 	f.Pragma = Pragmas(prags)
 	arg, ret, ok := typecheck.Func(pred)
@@ -699,7 +699,7 @@ type flatmapSlice struct {
 //	Flatmap(Slice<t1, t2, ..., tn>, func(v1 t1, v2 t2, ..., vn tn) ([]r1, []r2, ..., []rn)) Slice<r1, r2, ..., rn>
 func Flatmap(slice Slice, fn interface{}, prags ...Pragma) Slice {
 	f := new(flatmapSlice)
-	f.name = makeName("flatmap")
+	f.name = MakeName("flatmap")
 	f.Slice = slice
 	f.Pragma = Pragmas(prags)
 	arg, ret, ok := typecheck.Func(fn)
@@ -833,7 +833,7 @@ func Fold(slice Slice, fold interface{}) Slice {
 		typecheck.Panicf(1, "fold: key type %s cannot be accumulated", slice.Out(0))
 	}
 	f := new(foldSlice)
-	f.name = makeName("fold")
+	f.name = MakeName("fold")
 	f.Slice = slice
 	// Fold requires shuffle by the first column.
 	// TODO(marius): allow deps to express shuffling by other columns.
@@ -919,7 +919,7 @@ type headSlice struct {
 // each shard of the underlying slice. Its type is the same as the
 // provided slice.
 func Head(slice Slice, n int) Slice {
-	return &headSlice{makeName(fmt.Sprintf("head(%d)", n)), slice, n}
+	return &headSlice{MakeName(fmt.Sprintf("head(%d)", n)), slice, n}
 }
 
 func (h *headSlice) Name() Name             { return h.name }
@@ -958,7 +958,7 @@ type scanSlice struct {
 // It returns a unit Slice: Scan is inteded to be used for its side
 // effects.
 func Scan(slice Slice, scan func(shard int, scanner *sliceio.Scanner) error) Slice {
-	return &scanSlice{makeName("scan"), slice, scan}
+	return &scanSlice{MakeName("scan"), slice, scan}
 }
 
 func (s *scanSlice) Name() Name             { return s.name }
@@ -1077,7 +1077,7 @@ func (n Name) String() string {
 	return fmt.Sprintf("%s@%s:%d", n.Op, n.File, n.Line)
 }
 
-func makeName(op string) Name {
+func MakeName(op string) Name {
 	// Presume the correct frame is the caller of makeName,
 	// but skip to the frame before the last helper, if any.
 	var pc [50]uintptr             // consider at most 50 frames


### PR DESCRIPTION
Capture the (cache) environment used for compilation on the driver and propagate it to workers to make compilation stable with respect to cache state, i.e. same task graph is compiled even if workers see different cache state.  This should fix panics that we see cause by `task X not found` errors, in which unstable compilation leads the driver to try to run tasks on workers that have not compiled those tasks.

This includes some tweaks to support unit testing.

I also manually tested this with a test program that exercises this panic by causing machine death once the cache is populated.