### PR TITLE
Make slicetest use bigmachine with local system

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -5,7 +5,6 @@ package bigslice_test
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"

--- a/slicetest/run.go
+++ b/slicetest/run.go
@@ -19,8 +19,10 @@ import (
 	"github.com/grailbio/bigslice/sliceio"
 )
 
-var sessOnce sync.Once
-var sess *exec.Session
+var (
+	sessOnce sync.Once
+	sess     *exec.Session
+)
 
 // getSess returns the session to use for tests. It is created on the first
 // call.

--- a/slicetest/run_test.go
+++ b/slicetest/run_test.go
@@ -60,6 +60,10 @@ func randIntSlice(r *rand.Rand, n int) []int {
 	return ints
 }
 
+var runAndScan = bigslice.Func(func(strs []string, ints []int) bigslice.Slice {
+	return bigslice.Const(10, strs, ints)
+})
+
 func TestRunAndScan(t *testing.T) {
 	const N = 10000
 	var (
@@ -67,12 +71,12 @@ func TestRunAndScan(t *testing.T) {
 		strs = randStringSlice(r, N)
 		ints = randIntSlice(r, N)
 	)
-	slice := bigslice.Const(10, strs, ints)
 	var (
 		scannedStrs []string
 		scannedInts []int
 	)
-	slicetest.RunAndScan(t, slice, &scannedStrs, &scannedInts)
+	args := []interface{}{strs, ints}
+	slicetest.RunAndScan(t, runAndScan, args, &scannedStrs, &scannedInts)
 	if got, want := len(scannedStrs), N; got != want {
 		t.Fatalf("got %v, want %v", got, want)
 	}


### PR DESCRIPTION
Make slicetest use bigmachine with the local system, as this will exercise any gob-encoding that is necessary to compute the slice/func under test.  This requires Funcs to be deterministically created, as is the requirement for non-test bigslice programs.  Tests are updated with this requirement.