### PR TITLE
Set CompileEnv in Tasks

### DIFF
--- a/exec/compile.go
+++ b/exec/compile.go
@@ -233,6 +233,7 @@ func (c *compiler) compile(slice bigslice.Slice, part partitioner) (tasks []*Tas
 		for shard, task := range result.tasks {
 			tasks[shard] = &Task{
 				Type:       slice,
+				CompileEnv: c.env,
 				Invocation: c.inv,
 				Name: TaskName{
 					Op:       shuffleOpName,
@@ -269,6 +270,7 @@ func (c *compiler) compile(slice bigslice.Slice, part partitioner) (tasks []*Tas
 	for i := range tasks {
 		tasks[i] = &Task{
 			Type:         slices[0],
+			CompileEnv:   c.env,
 			Name:         TaskName{Op: opName, Shard: i, NumShard: len(tasks)},
 			Invocation:   c.inv,
 			Pragma:       pragmas,


### PR DESCRIPTION
This should have been part of f556b4be7cbc50b1a79c141bbc51858de1215b18 but was missed because of oversight.  It sets the `CompileEnv` of tasks to the environment used to compile the tasks.  This is later used when compiling tasks on workers.

This ends up being tested in https://github.com/grailbio/bigslice/pull/42 (and was found as a result of that work).