### PR TITLE
Add ReadCache slice operation

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -86,7 +86,8 @@ func (r *readCacheSlice) Reader(shard int, _ []sliceio.Reader) sliceio.Reader {
 // ReadCache reads from an existing cache but does not write any cache itself.
 // This may be useful if you want to reuse a cache from a previous computation
 // and fail if it does not exist. typ is the type of the cached and returned
-// slice.
+// slice. You may construct typ using slicetype.New or pass a Slice, which
+// embeds slicetype.Type.
 func ReadCache(ctx context.Context, typ slicetype.Type, numShard int, prefix string) Slice {
 	shardCache := slicecache.NewFileShardCache(ctx, prefix, numShard)
 	shardCache.RequireAllCached()

--- a/cache.go
+++ b/cache.go
@@ -10,6 +10,7 @@ import (
 	"github.com/grailbio/bigslice/internal/slicecache"
 	"github.com/grailbio/bigslice/slicefunc"
 	"github.com/grailbio/bigslice/sliceio"
+	"github.com/grailbio/bigslice/slicetype"
 )
 
 type cacheSlice struct {
@@ -41,13 +42,10 @@ func (c *cacheSlice) Cache() slicecache.ShardCache { return c.cache }
 //
 // Cache uses GRAIL's file library, so prefix may refer to URLs to a
 // distributed object store such as S3.
-func Cache(ctx context.Context, slice Slice, prefix string) (Slice, error) {
-	shardCache, err := slicecache.NewFileShardCache(ctx, prefix, slice.NumShard())
-	if err != nil {
-		return nil, err
-	}
+func Cache(ctx context.Context, slice Slice, prefix string) Slice {
+	shardCache := slicecache.NewFileShardCache(ctx, prefix, slice.NumShard())
 	shardCache.RequireAllCached()
-	return &cacheSlice{MakeName("cache"), slice, shardCache}, nil
+	return &cacheSlice{MakeName("cache"), slice, shardCache}
 }
 
 // CachePartial caches the output of the slice to the given file
@@ -62,10 +60,35 @@ func Cache(ctx context.Context, slice Slice, prefix string) (Slice, error) {
 // of a modifiable file in S3, CachePartial produces corrupt results.
 //
 // As with Cache, the user must guarantee cache consistency.
-func CachePartial(ctx context.Context, slice Slice, prefix string) (Slice, error) {
-	shardCache, err := slicecache.NewFileShardCache(ctx, prefix, slice.NumShard())
-	if err != nil {
-		return nil, err
-	}
-	return &cacheSlice{MakeName("cachepartial"), slice, shardCache}, nil
+func CachePartial(ctx context.Context, slice Slice, prefix string) Slice {
+	shardCache := slicecache.NewFileShardCache(ctx, prefix, slice.NumShard())
+	return &cacheSlice{MakeName("cachepartial"), slice, shardCache}
+}
+
+type readCacheSlice struct {
+	slicetype.Type
+	name     Name
+	numShard int
+	cache    *slicecache.FileShardCache
+}
+
+func (r *readCacheSlice) Name() Name             { return r.name }
+func (r *readCacheSlice) NumShard() int          { return r.numShard }
+func (*readCacheSlice) ShardType() ShardType     { return HashShard }
+func (*readCacheSlice) NumDep() int              { return 0 }
+func (*readCacheSlice) Dep(i int) Dep            { panic("no deps") }
+func (*readCacheSlice) Combiner() slicefunc.Func { return slicefunc.Nil }
+
+func (r *readCacheSlice) Reader(shard int, _ []sliceio.Reader) sliceio.Reader {
+	return r.cache.CacheReader(shard)
+}
+
+// ReadCache reads from an existing cache but does not write any cache itself.
+// This may be useful if you want to reuse a cache from a previous computation
+// and fail if it does not exist. typ is the type of the cached and returned
+// slice.
+func ReadCache(ctx context.Context, typ slicetype.Type, numShard int, prefix string) Slice {
+	shardCache := slicecache.NewFileShardCache(ctx, prefix, numShard)
+	shardCache.RequireAllCached()
+	return &readCacheSlice{typ, MakeName("readcache"), numShard, shardCache}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -294,8 +294,8 @@ func TestCacheErr(t *testing.T) {
 
 // TestReadCache verifies that ReadCache successfully reads from an existing cache.
 func TestReadCache(t *testing.T) {
-	dir, cleanup := testutil.TempDir(t, "", "")
-	defer cleanup()
+	dir, cleanUp := testutil.TempDir(t, "", "")
+	defer cleanUp()
 	prefix := filepath.Join(dir, "cached")
 	ctx := context.Background()
 
@@ -330,8 +330,8 @@ func TestReadCache(t *testing.T) {
 // TestReadCacheError verifies that a ReadCache reader returns an error if the
 // cache does not exist.
 func TestReadCacheError(t *testing.T) {
-	dir, cleanup := testutil.TempDir(t, "", "")
-	defer cleanup()
+	dir, cleanUp := testutil.TempDir(t, "", "")
+	defer cleanUp()
 	var (
 		prefix = filepath.Join(dir, "cached")
 		ctx    = context.Background()

--- a/cache_test.go
+++ b/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"testing"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/grailbio/bigslice/exec"
 	"github.com/grailbio/bigslice/sliceio"
 	"github.com/grailbio/bigslice/slicetest"
+	"github.com/grailbio/bigslice/slicetype"
 	"github.com/grailbio/testutil"
 )
 
@@ -32,12 +34,8 @@ func TestCache(t *testing.T) {
 			}
 			return i * 2
 		})
-		var err error
 		ctx := context.Background()
-		slice, err = bigslice.Cache(ctx, slice, filepath.Join(dir, "cached"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		slice = bigslice.Cache(ctx, slice, filepath.Join(dir, "cached"))
 		return slice
 	}
 	runTestCache(t, makeSlice)
@@ -65,12 +63,8 @@ func TestCacheDeps(t *testing.T) {
 			}
 			return i * 2
 		})
-		var err error
 		ctx := context.Background()
-		slice, err = bigslice.Cache(ctx, slice, filepath.Join(dir, "cached"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		slice = bigslice.Cache(ctx, slice, filepath.Join(dir, "cached"))
 		return slice
 	}
 	runTestCache(t, makeSlice)
@@ -155,11 +149,7 @@ func TestCacheIncremental(t *testing.T) {
 			rowsRan[i] = true
 			return i * 2
 		})
-		var err error
-		slice, err = bigslice.Cache(ctx, slice, filepath.Join(dir, "cached"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		slice = bigslice.Cache(ctx, slice, filepath.Join(dir, "cached"))
 		return slice
 	}
 
@@ -232,11 +222,7 @@ func TestCachePartialIncremental(t *testing.T) {
 			rowsRan[i] = true
 			return i * 2
 		})
-		var err error
-		slice, err = bigslice.CachePartial(ctx, slice, filepath.Join(dir, "cached"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		slice = bigslice.CachePartial(ctx, slice, filepath.Join(dir, "cached"))
 		return slice
 	}
 
@@ -306,11 +292,7 @@ func TestCacheErr(t *testing.T) {
 			computeRan = true
 			return len(ints), nil
 		})
-		var err error
-		slice, err = bigslice.Cache(ctx, slice, file.Join(dir, "cached"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		slice = bigslice.Cache(ctx, slice, file.Join(dir, "cached"))
 		return slice
 	}
 	if err := slicetest.RunErr(makeSlice()); err == nil {
@@ -325,6 +307,78 @@ func TestCacheErr(t *testing.T) {
 	}
 	if !computeRan {
 		t.Error()
+	}
+}
+
+// TestReadCache verifies that ReadCache successfully reads from an existing cache.
+func TestReadCache(t *testing.T) {
+	dir, cleanup := testutil.TempDir(t, "", "")
+	defer cleanup()
+	prefix := filepath.Join(dir, "cached")
+	ctx := context.Background()
+
+	const (
+		N      = 10000
+		Nshard = 10
+	)
+	input := make([]int, N)
+	for i := range input {
+		input[i] = i
+	}
+	slice1 := bigslice.Const(Nshard, input)
+	slice1 = bigslice.Cache(ctx, slice1, prefix)
+	scan1 := runLocal(ctx, t, slice1)
+	defer scan1.Close()
+
+	// We now have a populated cache. Read from it, and make sure we get the
+	// same results.
+	slice2 := bigslice.ReadCache(ctx, slice1, slice1.NumShard(), prefix)
+	scan2 := runLocal(ctx, t, slice2)
+	defer scan2.Close()
+
+	var n int
+	for {
+		var v1, v2 int
+		ok := scan1.Scan(ctx, &v1)
+		if got, want := scan2.Scan(ctx, &v2), ok; got != want {
+			t.Errorf("got %v, want %v", got, want)
+			break
+		}
+		if !ok {
+			break
+		}
+		if v1 != v2 {
+			t.Errorf("%v != %v", v1, v2)
+		}
+		n++
+	}
+	if got, want := n, N; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if err := scan1.Err(); err != nil {
+		t.Errorf("scan1: %v", err)
+	}
+	if err := scan2.Err(); err != nil {
+		t.Errorf("scan2: %v", err)
+	}
+}
+
+// TestReadCacheError verifies that a ReadCache reader returns an error if the
+// cache does not exist.
+func TestReadCacheError(t *testing.T) {
+	dir, cleanup := testutil.TempDir(t, "", "")
+	defer cleanup()
+	var (
+		prefix = filepath.Join(dir, "cached")
+		ctx    = context.Background()
+		slice  = bigslice.ReadCache(ctx, slicetype.New(reflect.TypeOf(0)), 1, prefix)
+		fn     = bigslice.Func(func() bigslice.Slice { return slice })
+		sess   = exec.Start(exec.Local)
+	)
+	defer sess.Shutdown()
+	_, err := sess.Run(ctx, fn)
+	if err == nil {
+		t.Errorf("expected error when reading from non-existent cache")
 	}
 }
 

--- a/internal/slicecache/slicecache.go
+++ b/internal/slicecache/slicecache.go
@@ -42,6 +42,14 @@ type FileShardCache struct {
 	requireAll    bool
 }
 
+const (
+	// pathFormat is the format used for the path of cache files.
+	pathFormat = "%s-%04d-of-%04d"
+	// pathFormatAllShards is the format used to refer to all of a cache's
+	// files, for human consumption.
+	pathFormatAllShards = "%s-NNNN-of-%04d"
+)
+
 // NewShardCache constructs a ShardCache. It does O(numShards) parallelized
 // file operations to look up what's present in the cache.
 func NewFileShardCache(ctx context.Context, prefix string, numShards int) *FileShardCache {
@@ -61,7 +69,7 @@ func NewFileShardCache(ctx context.Context, prefix string, numShards int) *FileS
 }
 
 func (c *FileShardCache) path(shard int) string {
-	return fmt.Sprintf("%s-%04d-of-%04d", c.prefix, shard, c.numShards)
+	return fmt.Sprintf(pathFormat, c.prefix, shard, c.numShards)
 }
 
 func (c *FileShardCache) IsCached(shard int) bool {
@@ -101,7 +109,7 @@ func (c *FileShardCache) CacheReader(shard int) sliceio.Reader {
 	if !c.shardIsCached[shard] {
 		path := c.path(shard)
 		if c.requireAll {
-			path = fmt.Sprintf("%s-NNNN-of-%04d", c.prefix, c.numShards)
+			path = fmt.Sprintf(pathFormatAllShards, c.prefix, c.numShards)
 		}
 		err := fmt.Errorf("cache %q invalid for shard %d(%d); check %q",
 			c.prefix, shard, c.numShards, path)


### PR DESCRIPTION
Add a `ReadCache` slice operation that reads from an existing cache but does not write any cache itself. This may be useful if you want to reuse a cache from a previous computation and fail if it does not exist.

This change also removes the errors returned by the `Cache` and `CachePartial` operations, as they are never non-`nil`. They previously were used to signal an incomplete cache, but this is now handled by the `IsCached` method. This simplifies callers, especially since these are virtually always called within `bigslice.Func` definitions which do not an easy way to propagate errors.