### PR TITLE
Optionally write trace event file on shutdown

### DIFF
--- a/exec/config.go
+++ b/exec/config.go
@@ -17,6 +17,7 @@ func init() {
 		var system bigmachine.System
 		constr.InstanceVar(&system, "system", "", "the bigmachine system used for job execution")
 		constr.FloatVar(&sess.maxLoad, "max-load", DefaultMaxLoad, "per-machine maximum load")
+		constr.StringVar(&sess.tracePath, "trace-path", "", "path at which to write trace event file")
 		constr.Doc = "bigslice configures the bigslice runtime"
 		constr.New = func() (interface{}, error) {
 			if system != nil {

--- a/exec/session.go
+++ b/exec/session.go
@@ -380,13 +380,20 @@ func (r *Result) open() sliceio.ReadCloser {
 
 func writeTraceFile(tracer *tracer, path string) {
 	w, err := os.Create(path)
+	defer func() {
+		err := w.Close()
+		if err != nil {
+			log.Error.Printf("error closing trace file at %q: %v", path, err)
+			return
+		}
+	}()
 	if err != nil {
-		log.Error.Printf("could not create trace file at %q: %v", path, err)
+		log.Error.Printf("error creating trace file at %q: %v", path, err)
 		return
 	}
 	err = tracer.Marshal(w)
 	if err != nil {
-		log.Error.Printf("could not marshal to trace file at %q: %v", path, err)
+		log.Error.Printf("erro marshaling to trace file at %q: %v", path, err)
 		return
 	}
 }

--- a/exec/session.go
+++ b/exec/session.go
@@ -380,6 +380,10 @@ func (r *Result) open() sliceio.ReadCloser {
 
 func writeTraceFile(tracer *tracer, path string) {
 	w, err := os.Create(path)
+	if err != nil {
+		log.Error.Printf("error creating trace file at %q: %v", path, err)
+		return
+	}
 	defer func() {
 		err := w.Close()
 		if err != nil {
@@ -387,10 +391,6 @@ func writeTraceFile(tracer *tracer, path string) {
 			return
 		}
 	}()
-	if err != nil {
-		log.Error.Printf("error creating trace file at %q: %v", path, err)
-		return
-	}
 	err = tracer.Marshal(w)
 	if err != nil {
 		log.Error.Printf("erro marshaling to trace file at %q: %v", path, err)

--- a/exec/session.go
+++ b/exec/session.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -63,12 +64,13 @@ func init() {
 //	}
 type Session struct {
 	context.Context
-	index    int32
-	shutdown func()
-	p        int
-	maxLoad  float64
-	executor Executor
-	status   *status.Status
+	index     int32
+	shutdown  func()
+	p         int
+	maxLoad   float64
+	executor  Executor
+	status    *status.Status
+	tracePath string
 
 	machineCombiners bool
 
@@ -137,6 +139,14 @@ func Status(status *status.Status) Option {
 		dump.Register(name, func(ctx context.Context, w io.Writer) error {
 			return status.Marshal(w)
 		})
+	}
+}
+
+// TracePath configures the path to which a trace event file for the session
+// will be written on shutdown.
+func TracePath(path string) Option {
+	return func(s *Session) {
+		s.tracePath = path
 	}
 }
 
@@ -299,6 +309,9 @@ func (s *Session) Shutdown() {
 	if s.shutdown != nil {
 		s.shutdown()
 	}
+	if s.tracePath != "" {
+		writeTraceFile(s.tracer, s.tracePath)
+	}
 }
 
 // Status returns the session's status aggregator.
@@ -363,4 +376,17 @@ func (r *Result) open() sliceio.ReadCloser {
 		readers[i] = r.sess.executor.Reader(r.tasks[i], 0)
 	}
 	return sliceio.MultiReader(readers...)
+}
+
+func writeTraceFile(tracer *tracer, path string) {
+	w, err := os.Create(path)
+	if err != nil {
+		log.Error.Printf("could not create trace file at %q: %v", path, err)
+		return
+	}
+	err = tracer.Marshal(w)
+	if err != nil {
+		log.Error.Printf("could not marshal to trace file at %q: %v", path, err)
+		return
+	}
 }


### PR DESCRIPTION
Add the ability to configure sessions to write a trace event file on shutdown. This gives us an easy way to get a trace file that covers the entire session, which can be useful for visualization and optimization.