### PR TITLE
Shut down sessions returned by Parse

### DIFF
--- a/cmd/badfuncs/main.go
+++ b/cmd/badfuncs/main.go
@@ -47,16 +47,16 @@ func ok() {
 	for i, makeFunc := range makeFuncs {
 		funcs[i] = makeFunc()
 	}
-	sess, shutdown := sliceconfig.Parse()
-	defer shutdown()
+	sess := sliceconfig.Parse()
+	defer sess.Shutdown()
 
 	ctx := context.Background()
 	sess.Must(ctx, funcs[0])
 }
 
 func toolate() {
-	sess, shutdown := sliceconfig.Parse()
-	defer shutdown()
+	sess := sliceconfig.Parse()
+	defer sess.Shutdown()
 
 	f0 := makeFuncs[0]()
 	ctx := context.Background()
@@ -72,8 +72,8 @@ func random() {
 	for i, makeFunc := range makeFuncs {
 		funcs[i] = makeFunc()
 	}
-	sess, shutdown := sliceconfig.Parse()
-	defer shutdown()
+	sess := sliceconfig.Parse()
+	defer sess.Shutdown()
 	ctx := context.Background()
 	sess.Must(ctx, funcs[0])
 }

--- a/cmd/slicer/main.go
+++ b/cmd/slicer/main.go
@@ -39,8 +39,8 @@ Available test are:
 	}
 
 	wait := flag.Bool("wait", false, "don't exit after completion")
-	sess, shutdown := sliceconfig.Parse()
-	defer shutdown()
+	sess := sliceconfig.Parse()
+	defer sess.Shutdown()
 
 	if flag.NArg() == 0 {
 		flag.Usage()

--- a/cmd/urls/urls.go
+++ b/cmd/urls/urls.go
@@ -102,8 +102,8 @@ func main() {
 		n   = flag.Int("n", 1000, "number of shards to process")
 		out = flag.String("out", "", "output path")
 	)
-	sess, shutdown := sliceconfig.Parse()
-	defer shutdown()
+	sess := sliceconfig.Parse()
+	defer sess.Shutdown()
 
 	must.True(*out != "", "missing flag -out")
 

--- a/sliceconfig/sliceconfig.go
+++ b/sliceconfig/sliceconfig.go
@@ -38,19 +38,20 @@ import (
 // by Parse.
 var Path = os.ExpandEnv("$HOME/.bigslice/config")
 
-// Parse registers configuration flags, bigslice flags, and calls
-// flag.Parse. It reads bigslice configuration from Path defined in
-// this package. Parse returns session as configured by the
-// configuration and any flags provided. Parse panics if session
-// creation fails. Parse also instantiates the default http server
-// according to the configuration profile, and registers the bigslice
-// session status handlers with it.
-func Parse() (sess *exec.Session, shutdown func()) {
+// Parse registers configuration flags, bigslice flags, and calls flag.Parse. It
+// reads bigslice configuration from Path defined in this package. Parse returns
+// a session as configured by the configuration and any flags provided. Parse
+// panics if session creation fails. Parse also instantiates the default http
+// server according to the configuration profile, and registers the bigslice
+// session status handlers with it. Call Shutdown() on the returned session when
+// you are done with it.
+func Parse() *exec.Session {
 	log.AddFlags()
 	local := flag.Bool("local", false, "run bigslice in local mode")
 	config.RegisterFlags("", Path)
 	flag.Parse()
 	must.Nil(config.ProcessFlags())
+	var sess *exec.Session
 	if *local {
 		sess = exec.Start(exec.Local, exec.Status(new(status.Status)))
 	} else {
@@ -60,5 +61,5 @@ func Parse() (sess *exec.Session, shutdown func()) {
 	sess.HandleDebug(http.DefaultServeMux)
 	http.Handle("/debug/status", status.Handler(sess.Status()))
 	config.Must("http", nil)
-	return sess, func() {}
+	return sess
 }


### PR DESCRIPTION
Shut down sessions returned by Parse in various test programs. Also simplify the API to Parse. It was previously returning the session and a no-op shutdown function. Instead, just return the session and have callers shut down the session itself.