### PR TITLE
Track dependencies correctly given task loss

### DIFF
--- a/exec/eval.go
+++ b/exec/eval.go
@@ -28,6 +28,12 @@ var defaultChunksize = &defaultsize.Chunk
 // evaluation (e.g. an error that causes worker processes to exit).
 const maxConsecutiveLost = 5
 
+// enableMaxConsecutiveLost enables the use of the maxConsecutiveLost value to
+// consider repeatedly lost tasks as errors. See documentation for
+// maxConsecutiveLost. It is exposed so that we can disable it in some testing
+// scenarios.
+var enableMaxConsecutiveLost = true
+
 // Executor defines an interface used to provide implementations of
 // task runners. An Executor is responsible for running single tasks,
 // partitioning their outputs, and instantiating readers to retrieve the
@@ -121,21 +127,10 @@ func Eval(ctx context.Context, executor Executor, roots []*Task, group *status.G
 					err = task.Wait(ctx)
 				}
 				if runner {
-					// Only the runner bookkeeps consecutiveLost to avoid
-					// double-counting task loss.
-					switch task.state {
-					case TaskOk:
-						task.consecutiveLost = 0
-					case TaskLost:
-						task.consecutiveLost++
-						if task.consecutiveLost >= maxConsecutiveLost {
-							// We've lost this task too many times, so we
-							// consider it in error.
-							task.state = TaskErr
-							task.err = fmt.Errorf("lost on %d consecutive attempts", task.consecutiveLost)
-							task.Status.Printf(task.err.Error())
-							task.Broadcast()
-						}
+					if enableMaxConsecutiveLost {
+						// Only the runner bookkeeps consecutiveLost to avoid
+						// double-counting task loss.
+						updateConsecutiveLost(task)
 					}
 					d := time.Since(startRunTime)
 					executor.Eventer().Event("bigslice:taskComplete",
@@ -231,6 +226,7 @@ func (s *state) Enqueue(task *Task) (nwait int) {
 			s.schedule(task)
 			nwait++
 		case TaskInit, TaskLost:
+			s.clear(task)
 			ready := true
 			for _, dep := range task.Deps {
 				n := s.Enqueue(dep.Head)
@@ -239,7 +235,6 @@ func (s *state) Enqueue(task *Task) (nwait int) {
 				}
 				s.add(dep.Head, task, n)
 				ready = false
-				continue
 			}
 			nwait++
 			if ready {
@@ -321,6 +316,16 @@ func (s *state) schedule(task *Task) {
 	s.todo[task] = true
 }
 
+// Clear the dependency information stored for task.
+func (s *state) clear(task *Task) {
+	delete(s.counts, task)
+	for _, dep := range task.Deps {
+		if d := s.deps[dep.Head]; d != nil {
+			delete(d, task)
+		}
+	}
+}
+
 // Add adds a dependency from the provided src to dst tasks.
 func (s *state) add(src, dst *Task, n int) {
 	if d := s.deps[src]; d == nil {
@@ -345,8 +350,26 @@ func (s *state) done(src *Task) (ready []*Task) {
 		s.counts[dst]--
 		if s.counts[dst] == 0 {
 			ready = append(ready, dst)
-			delete(s.deps[src], dst)
 		}
 	}
 	return
+}
+
+// updateConsecutiveLost updates the accounting of consecutive task loss,
+// promoting the TaskLost to TaskErr if we exceed maxConsecutiveLost.
+func updateConsecutiveLost(task *Task) {
+	switch task.state {
+	case TaskOk:
+		task.consecutiveLost = 0
+	case TaskLost:
+		task.consecutiveLost++
+		if task.consecutiveLost >= maxConsecutiveLost {
+			// We've lost this task too many times, so we
+			// consider it in error.
+			task.state = TaskErr
+			task.err = fmt.Errorf("lost on %d consecutive attempts", task.consecutiveLost)
+			task.Status.Printf(task.err.Error())
+			task.Broadcast()
+		}
+	}
 }

--- a/exec/evalstress_test.go
+++ b/exec/evalstress_test.go
@@ -1,0 +1,177 @@
+// Copyright 2020 GRAIL, Inc. All rights reserved.
+// Use of this source code is governed by the Apache 2.0
+// license that can be found in the LICENSE file.
+
+package exec
+
+import (
+	"context"
+	"math/rand"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grailbio/base/eventlog"
+	"github.com/grailbio/bigslice"
+	"github.com/grailbio/bigslice/sliceio"
+)
+
+// stressExecutor implements Executor with randomized task loss to stress the
+// correctness of evaluation.
+type stressExecutor struct {
+	wg sync.WaitGroup
+	// tasksOk is the set of tasks that this executor has ever successfully
+	// completed. We use this to verify that once Eval returns, all root tasks
+	// have, at least at some point, completed successfully.
+	tasksOk map[*Task]bool
+	// cTasksOk is sent tasks to be recorded in tasksOk.
+	cTasksOk chan *Task
+	// cReadTaskOk is sent requests to read whether a task a task has ever been
+	// completed successfully by this executor.
+	cReadTaskOk chan msgReadTaskOk
+	errorRate   float64
+}
+
+type msgReadTaskOk struct {
+	task *Task
+	c    chan bool
+}
+
+func newStressExecutor() *stressExecutor {
+	e := &stressExecutor{
+		tasksOk:     make(map[*Task]bool),
+		cTasksOk:    make(chan *Task),
+		cReadTaskOk: make(chan msgReadTaskOk),
+	}
+	return e
+}
+
+func (*stressExecutor) Name() string {
+	return "stress"
+}
+
+func (e *stressExecutor) Start(*Session) func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	go e.loop(ctx)
+	return func() {
+		cancel()
+		e.wg.Wait()
+	}
+}
+
+// delay delays for a random duration to exercise different sequencing.
+func delay() {
+	delayMS := time.Duration(rand.Intn(50) + 10)
+	<-time.After(delayMS * time.Millisecond)
+}
+
+func (e *stressExecutor) Run(task *Task) {
+	e.wg.Add(1)
+	go func() {
+		defer e.wg.Done()
+		delay()
+		task.Set(TaskRunning)
+		completionState := TaskOk
+		if rand.Float64() < e.errorRate {
+			completionState = TaskLost
+		}
+		delay()
+		if completionState == TaskOk {
+			e.cTasksOk <- task
+		}
+		task.Set(completionState)
+	}()
+}
+
+func (*stressExecutor) Reader(*Task, int) sliceio.ReadCloser {
+	panic("not implemented")
+}
+
+func (*stressExecutor) Eventer() eventlog.Eventer {
+	return eventlog.Nop{}
+}
+
+func (*stressExecutor) HandleDebug(handler *http.ServeMux) {
+	panic("not implemented")
+}
+
+func (e *stressExecutor) loop(ctx context.Context) {
+	for {
+		select {
+		case task := <-e.cTasksOk:
+			e.tasksOk[task] = true
+			if rand.Float64() < e.errorRate {
+				// Simulate spontaneous task loss.
+				e.wg.Add(1)
+				go func() {
+					defer e.wg.Done()
+					delay()
+					task.Set(TaskLost)
+				}()
+			}
+		case m := <-e.cReadTaskOk:
+			m.c <- e.tasksOk[m.task]
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (e *stressExecutor) taskOk(task *Task) bool {
+	c := make(chan bool)
+	e.cReadTaskOk <- msgReadTaskOk{task: task, c: c}
+	return <-c
+}
+
+func (e *stressExecutor) setErrorRate(errorRate float64) {
+	e.errorRate = errorRate
+}
+
+// TestEvalStress verifies that evaluation behaves properly in the face of task
+// loss.
+func TestEvalStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	// Disable handling of consecutive lost tasks so that the evaluator tries
+	// indefinitely. We will be stressing the evaluator with very high error
+	// rates and are verifying its behavior, even though in practice we would
+	// give up, as error rates this high would generally mean some systematic
+	// problem that needs to be fixed.
+	enableMaxConsecutiveLost = false
+	var (
+		executor = newStressExecutor()
+		shutdown = executor.Start(nil)
+		ctx      = context.Background()
+	)
+	for i := 0; i < 10; i++ {
+		tasks, _, _ := compileFunc(func() bigslice.Slice {
+			vs := make([]int, 1000)
+			for i := range vs {
+				vs[i] = i
+			}
+			slice := bigslice.Const(100, vs)
+			slice2 := bigslice.Const(100, vs)
+			slice = bigslice.Cogroup(slice)
+			slice = bigslice.Map(slice, func(i int) int { return i + 1 })
+			slice = bigslice.Cogroup(slice, slice2)
+			slice = bigslice.Map(slice, func(i int) (int, int) { return i, i + 1 })
+			slice = bigslice.Reduce(slice, func(a, b int) int { return a + b })
+			return slice
+		})
+		executor.setErrorRate(rand.Float64() * 0.2)
+		err := Eval(ctx, executor, tasks, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Verify that all root tasks have been computed successfully at some
+		// point.
+		for _, task := range tasks {
+			if !executor.taskOk(task) {
+				t.Errorf("task not evaluated: %v", task)
+			}
+		}
+	}
+	shutdown()
+}


### PR DESCRIPTION
Track dependencies correctly given task loss. Fixes the following scenario:

1. Task `A` depends on  `B` and `C`. Nothing has yet been evaluated. `A`'s dependency count is 2.
2. `B` is successfully evaluated. `A`'s dependency count goes to 1.
3. `C` is successfully evaluated. `B` is concurrently lost. `A`'s dependency count goes to 0.
4. `A` is enqueued, sees that `B` is lost. Because it is still in the dependency set, `A`'s count is not updated.
5. `B` completes. `A`'s count goes to -1, so it is not enqueued.
6. There is nothing to do, and nothing pending. Evaluation returns without `A`, the root, ever having been evaluated successfully.

Fix this by clearing dependency information before reconstructing it in `Enqueue`.

Add a stress test that abuses evaluation with lost tasks. The test reliably produces the problem scenario.