### PR TITLE
Remove unhelpful log message

### DIFF
--- a/cmd/slicetrace/session.go
+++ b/cmd/slicetrace/session.go
@@ -123,7 +123,8 @@ func buildInvs(events []trace.Event) []invocation {
 			continue
 		}
 		if _, ok := invByIndex[index]; ok {
-			log.Printf("unexpected invocation index %q: %#v", event.Name, event)
+			// We just assume that the invocations across machines are all the
+			// same, so we just take the first one, and ignore the rest.
 			continue
 		}
 		var args []string


### PR DESCRIPTION
Remove unhelpful log message written when we see an "invocation" event with an invocation index that we've already seen. We actually expect the same invocation index event for each machine. We just assume that they are all the same, and use the information from the first one. The log is unhelpful.