### PR TITLE
Free ephemeral resources used for scanning

### DIFF
--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -1393,7 +1393,10 @@ func (r *openerAtReader) Close() error {
 	if r.readCloser == nil {
 		return nil
 	}
-	return r.readCloser.Close()
+	r.sliceioReader = nil
+	err := r.readCloser.Close()
+	r.readCloser = nil
+	return err
 }
 
 // machineTaskPartition is a task partition on a specific machine. It implements

--- a/sliceio/reader.go
+++ b/sliceio/reader.go
@@ -93,6 +93,7 @@ func (m *multiReader) Read(ctx context.Context, out frame.Frame) (n int, err err
 			// There's not much for us to do if the Close fails, so we just
 			// ignore it.
 			_ = m.q[0].Close()
+			m.q[0] = nil
 			m.q = m.q[1:]
 		case err != nil:
 			m.err = err
@@ -106,11 +107,15 @@ func (m *multiReader) Read(ctx context.Context, out frame.Frame) (n int, err err
 
 func (m *multiReader) Close() error {
 	var err error
-	for _, r := range m.q {
+	for i, r := range m.q {
+		if r == nil {
+			continue
+		}
 		cerr := r.Close()
 		if err == nil {
 			err = cerr
 		}
+		m.q[i] = nil
 	}
 	return err
 }


### PR DESCRIPTION
When we scan results, we get a slice of `*openerAtReader`s, one for each result task. We read from each reader sequentially. When we are done with a given reader, we retain some of the resources used when reading from it, most notably `gob` decode buffers. As we scan, we accumulate these defunct buffers, and our memory footprint grows.

This happens for two reasons:

1. We pop off the slice of readers to iterate, i.e. `q = q[1:]`. However, we do not clear the backing array reference to the reader.
2. When we close the reader, we don't clear the `sliceioReader`, which in turn holds the `gob` decoder.

Fixing either would eliminate the specific scan leak. Fix both, as I think it's the correct behavior.