### PR TITLE
Stop setting up Go 1.13 for linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,6 @@ jobs:
     steps:
     - name: Check out
       uses: actions/checkout@v2
-      # Use 1.13, as v.io's go.mod causes an error in 1.14. It improperly
-      # specifies a patch version for its Go version:
-      # https://github.com/vanadium/core/blob/v0.1.7/go.mod#L3. Remove this when
-      # we upgrade to a v.io that does not have this problem.
-    - name: Set up Go 1.13
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.13
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v1
       with:


### PR DESCRIPTION
Stop setting up Go 1.13 for linting, as #82 upgrades `v.io/core` to a version that no longer has a problem working with Go 1.14.