### PR TITLE
Reuse Func argument gob-encoding

### DIFF
--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -580,7 +580,9 @@ func (w *worker) Compile(ctx context.Context, invReader io.Reader, _ *struct{}) 
 	dec := gob.NewDecoder(invReader)
 	var inv execInvocation
 	if err = dec.Decode(&inv); err != nil {
-		return errors.E(errors.Fatal, errors.Invalid, "could not decode invocation", err)
+		// We may want to distinguish read errors from decode errors and
+		// consider the latter fatal.
+		return errors.E(errors.Invalid, "could not decode invocation", err)
 	}
 	return w.compiles.Do(inv.Index, func() error {
 		// Substitute invocation refs for the results of the invocation.

--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -576,9 +576,8 @@ func (w *worker) Compile(ctx context.Context, invReader io.Reader, _ *struct{}) 
 			err = errors.E(errors.Fatal, err)
 		}
 	}()
-	dec := gob.NewDecoder(invReader)
 	var inv execInvocation
-	if err = dec.Decode(&inv); err != nil {
+	if err = gob.NewDecoder(invReader).Decode(&inv); err != nil {
 		// We may want to distinguish read errors from decode errors and
 		// consider the latter fatal.
 		return errors.E(errors.Invalid, "could not decode invocation", err)

--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -187,15 +187,15 @@ func (b *bigmachineExecutor) compile(ctx context.Context, m *sliceMachine, inv e
 			if !ok {
 				continue
 			}
-			inv.Args[i] = invocationRef{result.inv.Index}
-			if _, ok := b.invocations[result.inv.Index]; !ok {
+			inv.Args[i] = invocationRef{result.invIndex}
+			if _, ok := b.invocations[result.invIndex]; !ok {
 				b.mu.Unlock()
-				return fmt.Errorf("invalid result invocation %x", result.inv.Index)
+				return fmt.Errorf("invalid result invocation %x", result.invIndex)
 			}
 			if b.invocationDeps[inv.Index] == nil {
 				b.invocationDeps[inv.Index] = make(map[uint64]bool)
 			}
-			b.invocationDeps[inv.Index][result.inv.Index] = true
+			b.invocationDeps[inv.Index][result.invIndex] = true
 		}
 		b.invocations[inv.Index] = inv
 

--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -578,8 +578,6 @@ func (w *worker) Compile(ctx context.Context, invReader io.Reader, _ *struct{}) 
 	}()
 	var inv execInvocation
 	if err = gob.NewDecoder(invReader).Decode(&inv); err != nil {
-		// We may want to distinguish read errors from decode errors and
-		// consider the latter fatal.
 		return errors.E(errors.Invalid, "error gob-decoding invocation", err)
 	}
 	return w.compiles.Do(inv.Index, func() error {

--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -203,7 +203,7 @@ func (b *bigmachineExecutor) compile(ctx context.Context, m *sliceMachine, inv e
 		// when sending the invocation to each worker.
 		var buf bytes.Buffer
 		if err := gob.NewEncoder(&buf).Encode(inv); err != nil {
-			return errors.E(errors.Fatal, errors.Invalid, err)
+			return errors.E(errors.Fatal, errors.Invalid, "error gob-encoding invocation", err)
 		}
 		b.encodedInvocations[inv.Index] = buf.Bytes()
 	}
@@ -580,7 +580,7 @@ func (w *worker) Compile(ctx context.Context, invReader io.Reader, _ *struct{}) 
 	if err = gob.NewDecoder(invReader).Decode(&inv); err != nil {
 		// We may want to distinguish read errors from decode errors and
 		// consider the latter fatal.
-		return errors.E(errors.Invalid, "could not decode invocation", err)
+		return errors.E(errors.Invalid, "error gob-decoding invocation", err)
 	}
 	return w.compiles.Do(inv.Index, func() error {
 		// Substitute invocation refs for the results of the invocation.

--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -577,8 +577,8 @@ func (w *worker) Compile(ctx context.Context, invReader io.Reader, _ *struct{}) 
 			err = errors.E(errors.Fatal, err)
 		}
 	}()
-	var inv execInvocation
 	dec := gob.NewDecoder(invReader)
+	var inv execInvocation
 	if err = dec.Decode(&inv); err != nil {
 		return errors.E(errors.Fatal, errors.Invalid, "could not decode invocation", err)
 	}

--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -201,12 +201,11 @@ func (b *bigmachineExecutor) compile(ctx context.Context, m *sliceMachine, inv e
 
 		// gob-encode the invocation, so we can reuse the work of gob-encoding
 		// when sending the invocation to each worker.
-		var invocationBuffer bytes.Buffer
-		enc := gob.NewEncoder(&invocationBuffer)
-		if err := enc.Encode(inv); err != nil {
+		var buf bytes.Buffer
+		if err := gob.NewEncoder(&buf).Encode(inv); err != nil {
 			return errors.E(errors.Fatal, errors.Invalid, err)
 		}
-		b.encodedInvocations[inv.Index] = invocationBuffer.Bytes()
+		b.encodedInvocations[inv.Index] = buf.Bytes()
 	}
 
 	// Now traverse the invocation graph bottom-up, making sure

--- a/exec/bigmachine_test.go
+++ b/exec/bigmachine_test.go
@@ -472,7 +472,10 @@ func TestBigmachineCompiler(t *testing.T) {
 	firstTasks := tasks
 	run(t, x, tasks, TaskOk)
 	tasks, _, _ = compileFunc(func() bigslice.Slice {
-		return bigslice.Map(&Result{Slice: slice, inv: inv, tasks: firstTasks}, func(i int) int { return i * 2 })
+		return bigslice.Map(
+			&Result{Slice: slice, invIndex: inv.Index, tasks: firstTasks},
+			func(i int) int { return i * 2 },
+		)
 	})
 	run(t, x, tasks, TaskOk)
 }

--- a/exec/bigmachine_test.go
+++ b/exec/bigmachine_test.go
@@ -80,12 +80,12 @@ func TestBigmachineExecutorExclusive(t *testing.T) {
 	var maxIndex int
 	wg.Add(2 * N) //one for local invocation; one for remote
 	for i := 0; i < N; i++ {
-		inv := fn.Invocation("<test>", i)
+		inv := makeExecInvocation(fn.Invocation("<test>", i))
 		if ix := int(inv.Index); ix > maxIndex {
 			maxIndex = ix
 		}
 		slice := inv.Invoke()
-		tasks, err := compile(makeCompileEnv(), slice, inv, false)
+		tasks, err := compile(inv, slice, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -120,9 +120,9 @@ func TestBigmachineExecutorTaskExclusive(t *testing.T) {
 		}, bigslice.Exclusive)
 		return slice
 	})
-	inv := fn.Invocation("<test>")
+	inv := makeExecInvocation(fn.Invocation("<test>"))
 	slice := inv.Invoke()
-	tasks, err := compile(makeCompileEnv(), slice, inv, false)
+	tasks, err := compile(inv, slice, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,9 +218,9 @@ func TestBigmachineExecutorProcs(t *testing.T) {
 		}, bigslice.Procs(2))
 		return slice
 	})
-	inv := fn.Invocation("<test>")
+	inv := makeExecInvocation(fn.Invocation("<test>"))
 	slice := inv.Invoke()
-	tasks, err := compile(makeCompileEnv(), slice, inv, false)
+	tasks, err := compile(inv, slice, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -621,22 +621,22 @@ func bigmachineTestExecutor(p int) (exec *bigmachineExecutor, stop func()) {
 	}
 }
 
-func compileFunc(f func() bigslice.Slice) ([]*Task, bigslice.Slice, bigslice.Invocation) {
+func compileFunc(f func() bigslice.Slice) ([]*Task, bigslice.Slice, execInvocation) {
 	fn := bigslice.Func(f)
-	inv := fn.Invocation("")
+	inv := makeExecInvocation(fn.Invocation(""))
 	slice := inv.Invoke()
-	tasks, err := compile(makeCompileEnv(), slice, inv, false)
+	tasks, err := compile(inv, slice, false)
 	if err != nil {
 		panic(err)
 	}
 	return tasks, slice, inv
 }
 
-func compileFuncExclusive(f func() bigslice.Slice) ([]*Task, bigslice.Slice, bigslice.Invocation) {
+func compileFuncExclusive(f func() bigslice.Slice) ([]*Task, bigslice.Slice, execInvocation) {
 	fn := bigslice.Func(f).Exclusive()
-	inv := fn.Invocation("")
+	inv := makeExecInvocation(fn.Invocation(""))
 	slice := inv.Invoke()
-	tasks, err := compile(makeCompileEnv(), slice, inv, false)
+	tasks, err := compile(inv, slice, false)
 	if err != nil {
 		panic(err)
 	}

--- a/exec/session.go
+++ b/exec/session.go
@@ -344,10 +344,10 @@ func (s *Session) run(ctx context.Context, calldepth int, funcv *bigslice.FuncVa
 	}
 	s.mu.Unlock()
 	return &Result{
-		Slice: slice,
-		sess:  s,
-		inv:   inv,
-		tasks: tasks,
+		Slice:    slice,
+		sess:     s,
+		invIndex: inv.Index,
+		tasks:    tasks,
 	}, Eval(ctx, s.executor, tasks, taskGroup)
 }
 
@@ -397,7 +397,7 @@ func (s *Session) HandleDebug(handler *http.ServeMux) {
 // bigslice.Func.
 type Result struct {
 	bigslice.Slice
-	inv       execInvocation
+	invIndex  uint64
 	sess      *Session
 	tasks     []*Task
 	initScope sync.Once

--- a/exec/session.go
+++ b/exec/session.go
@@ -265,6 +265,21 @@ func (s *Session) start() {
 	})
 }
 
+// execInvocation embeds bigslice.Invocation and is augmented with fields used
+// for execution.
+type execInvocation struct {
+	bigslice.Invocation
+	// Env is the compilation environment
+	Env CompileEnv
+}
+
+func makeExecInvocation(inv bigslice.Invocation) execInvocation {
+	return execInvocation{
+		Invocation: inv,
+		Env:        makeCompileEnv(),
+	}
+}
+
 // statusMu is used to prevent interleaving of slice and task status groups.
 // Unrelated status groups may be interleaved, but we are at least internally
 // consistent.
@@ -277,7 +292,7 @@ func (s *Session) run(ctx context.Context, calldepth int, funcv *bigslice.FuncVa
 		defer typecheck.Location(file, line)
 	}
 	var (
-		inv        bigslice.Invocation
+		inv        execInvocation
 		slice      bigslice.Slice
 		tasks      []*Task
 		sliceGroup *status.Group
@@ -291,17 +306,16 @@ func (s *Session) run(ctx context.Context, calldepth int, funcv *bigslice.FuncVa
 	err := func() error {
 		statusMu.Lock()
 		defer statusMu.Unlock()
-		inv = funcv.Invocation(location, args...)
+		inv = makeExecInvocation(funcv.Invocation(location, args...))
 		slice = inv.Invoke()
-		env := makeCompileEnv()
 		var err error
-		tasks, err = compile(env, slice, inv, s.machineCombiners)
+		tasks, err = compile(inv, slice, s.machineCombiners)
 		if err != nil {
 			return err
 		}
 		// Freeze the environment to ensure that compilations are consistent
 		// (e.g. across workers).
-		env.Freeze()
+		inv.Env.Freeze()
 		// TODO(marius): give a way to provide names for these groups
 		if s.status != nil {
 			// Make the slice status group come before the more granular task
@@ -383,7 +397,7 @@ func (s *Session) HandleDebug(handler *http.ServeMux) {
 // bigslice.Func.
 type Result struct {
 	bigslice.Slice
-	inv       bigslice.Invocation
+	inv       execInvocation
 	sess      *Session
 	tasks     []*Task
 	initScope sync.Once

--- a/exec/task.go
+++ b/exec/task.go
@@ -220,12 +220,9 @@ func (s *TaskSubscriber) Tasks() []*Task {
 // conditional variable to coordinate runtime state changes.
 type Task struct {
 	slicetype.Type
-	// CompileEnv is the compilation environment used/constructed for
-	// compilation of this task.
-	CompileEnv CompileEnv
 	// Invocation is the task's invocation, i.e. the Func invocation
 	// from which this task was compiled.
-	Invocation bigslice.Invocation
+	Invocation execInvocation
 	// Name is the name of the task. Tasks are named uniquely inside each
 	// Bigslice session.
 	Name TaskName

--- a/exec/tracer.go
+++ b/exec/tracer.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/grailbio/bigslice"
 	"github.com/grailbio/bigslice/internal/trace"
 )
 
@@ -118,7 +117,7 @@ func (t *tracer) Event(mach *sliceMachine, subject interface{}, ph string, args 
 		event.Cat = "task"
 		t.assignTid(mach, ph, t.taskEvents[arg], &event)
 		t.taskEvents[arg] = append(t.taskEvents[arg], event)
-	case bigslice.Invocation:
+	case execInvocation:
 		var name strings.Builder
 		fmt.Fprint(&name, arg.Index)
 		if arg.Exclusive {


### PR DESCRIPTION
Reuse `Func` argument gob-encoding for `Worker.Compile` calls. Arguments may be large. Gob-encoding uses an internal buffer for decoding that's at least the size of the value being encoded. We may call `Worker.Compile` for many workers concurrently. This can use excessive memory, e.g. 500MB * 50 workers. We have seen this lead to OOMs with real workloads.

By reusing, we hold on to the gob-encoding and reuse it for all calls for that invocation. We end up holding on to this buffer, but we avoid the spikes of concurrent encoding.

This PR also refactors the compilation environment code to make the coupling to invocation more clear, as we rely on the environment being write-once for a given invocation.
