### PR TITLE
Fix `bigslice run` argument parsing

### DIFF
--- a/cmd/bigslice/bigslicecmd/run.go
+++ b/cmd/bigslice/bigslicecmd/run.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 
 	"github.com/grailbio/base/must"
 )
@@ -18,13 +20,27 @@ Command run builds and then runs the provided package or files. See
 // Run executes the supplied arguments as a subprocess. If no arguments are
 // supplied, Build(ctx, ".") is used to build the current package and run that.
 func Run(ctx context.Context, args []string) {
+	var buildIndex int
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			break
+		}
+		buildIndex++
+	}
 	var binary string
-	if len(args) == 0 {
+	if buildIndex == 0 {
 		binary = Build(ctx, []string{"."}, "")
 	} else {
-		binary, args = args[0], args[1:]
+		binary = Build(ctx, args[:buildIndex], "")
 	}
-	cmd := exec.CommandContext(ctx, binary, args...)
+	if !filepath.IsAbs(binary) {
+		// Build may return a relative path that may not include any path
+		// separators. If the name passed to CommandContext has no path
+		// separators, $PATH is searched instead of using the relative path.
+		// Ensure that the name has a path separator.
+		binary = "." + string(os.PathSeparator) + binary
+	}
+	cmd := exec.CommandContext(ctx, binary, args[buildIndex:]...)
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin

--- a/cmd/bigslice/run.go
+++ b/cmd/bigslice/run.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/grailbio/bigslice/cmd/bigslice/bigslicecmd"
 )
@@ -19,15 +18,11 @@ func runCmdUsage() {
 }
 
 func runCmd(args []string) {
-	var buildIndex int
-	for _, arg := range args {
-		if arg == "-help" || arg == "--help" {
-			runCmdUsage()
-		}
-		if strings.HasPrefix(arg, "-") {
-			break
-		}
-		buildIndex++
+	if len(args) == 0 {
+		runCmdUsage()
 	}
-	bigslicecmd.Run(context.Background(), args[buildIndex:])
+	if args[0] == "-help" || args[0] == "--help" {
+		runCmdUsage()
+	}
+	bigslicecmd.Run(context.Background(), args)
 }


### PR DESCRIPTION
Address https://github.com/grailbio/bigslice/issues/91.

In https://github.com/grailbio/bigslice/commit/c0b6e3dceccdc55b08fc9781b153c15666ef4120, argument parsing broke, as `bigslice/cmd.runCmd` passed half-parsed arguments to `bigslice/bigslicecmd.Run`.

Fix and improve this by:
* Moving all argument parsing, aside from `-help`, to `bigslice/bigslicecmd.Run`.
* Showing usage if no arguments are given to `run` or if the first argument is `-help` or `--help`. This change allows those flags to be passed to the program being run instead of being intercepted.
* Reinstating the assumption that `run` takes either a package or `*.go` files. It seems that https://github.com/grailbio/bigslice/commit/c0b6e3dceccdc55b08fc9781b153c15666ef4120 attempted to convert `run` to take a path to a binary. I think having this use `*.go` files makes more sense, as it mimics the `go` tool.
* Ensuring that the path passed to `CommandContext` is specified with a path separator, so `$PATH` is not searched.