### PR TITLE
Make new reader for invocation on each retry

### DIFF
--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -240,8 +240,10 @@ func (b *bigmachineExecutor) compile(ctx context.Context, m *sliceMachine, inv e
 				args[i] = truncatef(inv.Args[i])
 			}
 			b.sess.tracer.Event(m, inv, "B", "location", inv.Location, "args", args)
-			var invReader io.Reader = bytes.NewReader(encodedInvocations[i])
-			err := m.RetryCall(ctx, "Worker.Compile", invReader, nil)
+			makeInvReader := func() io.Reader {
+				return bytes.NewReader(encodedInvocations[i])
+			}
+			err := m.RetryCall(ctx, "Worker.Compile", makeInvReader, nil)
 			if err != nil {
 				b.sess.tracer.Event(m, inv, "E", "error", err)
 			} else {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.29.24
 	github.com/google/gofuzz v1.0.0
 	github.com/grailbio/base v0.0.9
-	github.com/grailbio/bigmachine v0.5.7
+	github.com/grailbio/bigmachine v0.5.8
 	github.com/grailbio/testutil v0.0.3
 	github.com/spaolacci/murmur3 v1.1.0
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e

--- a/go.sum
+++ b/go.sum
@@ -99,6 +99,8 @@ github.com/grailbio/bigmachine v0.5.6 h1:AVJ7tWEXRGqscjbQnr2uXi//JKKSxxJ8/xrm9dg
 github.com/grailbio/bigmachine v0.5.6/go.mod h1:cwLU340iN9dVoitv10KfDwkMBzhG/gGAgPOepRUUgIg=
 github.com/grailbio/bigmachine v0.5.7 h1:RaYi4wa4el62yqrw1qTB+KVmmlcS8VhDy59/l+8MMOk=
 github.com/grailbio/bigmachine v0.5.7/go.mod h1:wvOUthoZPxKKJ829ClWaO/uRTxaW3DLm7LyUQHO8ed0=
+github.com/grailbio/bigmachine v0.5.8 h1:LNOiBTPjk6P8JODqqItcysRzftEPhE59B1wSlKnpGy4=
+github.com/grailbio/bigmachine v0.5.8/go.mod h1:O9UMGp6FPD6dRJhpIImjnTs8uFG8smEDYSqdIoadS+Y=
 github.com/grailbio/v23/factories/grail v0.0.0-20190904050408-8a555d238e9a h1:kAl1x1ErQgs55bcm/WdoKCPny/kIF7COmC+UGQ9GKcM=
 github.com/grailbio/v23/factories/grail v0.0.0-20190904050408-8a555d238e9a/go.mod h1:2g5HI42KHw+BDBdjLP3zs+WvTHlDK3RoE8crjCl26y4=
 github.com/hanwen/go-fuse v1.0.0/go.mod h1:unqXarDXqzAk0rt98O2tVndEPIpUgLD9+rwFisZH3Ok=


### PR DESCRIPTION
Switch to use the `func() io.Reader` argument type for the RPC of `Worker.Compile`. By doing this, each attempt to make the RPC (retried on temporary failures) will transmit the entire encoded invocation. Before this commit, retry attempts to make the RPC would likely fail because the reader had already been (partially) read by the previous invocation. Instead, the `func` we pass in will be called for each retry attempt, and it will construct a reader that reads out the entire invocation.

Upgrade `bigmachine` to `v.0.5.8`, as that version supports `func() io.Reader` RPC arguments.