### PR TITLE
Remove redundant build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
         go-version: ${{ matrix.go }}
     - name: Check out
       uses: actions/checkout@v2
-    - name: Build
-      run: go build -v ./...
     - name: Test
       run: go test -v -short ./...
   golangci:


### PR DESCRIPTION
Running `go test ./...` builds everything anyway.