### PR TITLE
Make map function type-checking more accurate

### DIFF
--- a/accum_test.go
+++ b/accum_test.go
@@ -26,7 +26,10 @@ outer:
 			t.Errorf("expected to be able to make accumulator for %s", typ)
 			continue
 		}
-		step := slicefunc.Of(func(a, e int) int { return a + e })
+		step, ok := slicefunc.Of(func(a, e int) int { return a + e })
+		if !ok {
+			t.Fatal("unexpected bad func")
+		}
 		accum := makeAccumulator(typ, typeOfInt, step)
 		const N = 100
 		for i := 0; i < N; i++ {

--- a/exec/combiner_test.go
+++ b/exec/combiner_test.go
@@ -37,7 +37,11 @@ func deepEqual(f, g frame.Frame) bool {
 
 func TestCombiningFrame(t *testing.T) {
 	typ := slicetype.New(typeOfString, typeOfInt)
-	f := makeCombiningFrame(typ, slicefunc.Of(func(n, m int) int { return n + m }), 2, 1)
+	fn, ok := slicefunc.Of(func(n, m int) int { return n + m })
+	if !ok {
+		t.Fatal("unexpected bad func")
+	}
+	f := makeCombiningFrame(typ, fn, 2, 1)
 	if f == nil {
 		t.Fatal("nil frame")
 	}
@@ -65,7 +69,11 @@ func TestCombiningFrame(t *testing.T) {
 func TestCombiningFrameManyKeys(t *testing.T) {
 	const N = 100000
 	typ := slicetype.New(typeOfString, typeOfInt)
-	f := makeCombiningFrame(typ, slicefunc.Of(func(n, m int) int { return n + m }), 2, 1)
+	fn, ok := slicefunc.Of(func(n, m int) int { return n + m })
+	if !ok {
+		t.Fatal("unexpected bad func")
+	}
+	f := makeCombiningFrame(typ, fn, 2, 1)
 	if f == nil {
 		t.Fatal("nil frame")
 	}
@@ -113,8 +121,12 @@ func TestCombiningFrameManyKeys(t *testing.T) {
 func TestCombiner(t *testing.T) {
 	const N = 100
 	typ := slicetype.New(typeOfString, typeOfInt)
+	fn, ok := slicefunc.Of(func(n, m int) int { return n + m })
+	if !ok {
+		t.Fatal("unexpected bad func")
+	}
 	// Set a small target value to ensure spilling.
-	c, err := newCombiner(typ, "test", slicefunc.Of(func(n, m int) int { return n + m }), 2)
+	c, err := newCombiner(typ, "test", fn, 2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/reduce.go
+++ b/reduce.go
@@ -46,15 +46,16 @@ func Reduce(slice Slice, reduce interface{}) Slice {
 	if err := canMakeCombiningFrame(slice); err != nil {
 		typecheck.Panic(1, err.Error())
 	}
-	arg, ret, ok := typecheck.Func(reduce)
+	fn, ok := slicefunc.Of(reduce)
 	if !ok {
 		typecheck.Panicf(1, "reduce: invalid reduce function %T", reduce)
 	}
 	outputType := slice.Out(slice.NumOut() - 1)
-	if arg.NumOut() != 2 || arg.Out(0) != outputType || arg.Out(1) != outputType || ret.NumOut() != 1 || ret.Out(0) != outputType {
+	if fn.In.NumOut() != 2 || fn.In.Out(0) != outputType || fn.In.Out(1) != outputType ||
+		fn.Out.NumOut() != 1 || fn.Out.Out(0) != outputType {
 		typecheck.Panicf(1, "reduce: invalid reduce function %T, expected func(%s, %s) %s", reduce, outputType, outputType, outputType)
 	}
-	return &reduceSlice{slice, MakeName("reduce"), slicefunc.Of(reduce)}
+	return &reduceSlice{slice, MakeName("reduce"), fn}
 }
 
 // ReduceSlice implements "post shuffle" combining merge sort.

--- a/reshuffle_test.go
+++ b/reshuffle_test.go
@@ -107,10 +107,10 @@ func TestRepartition(t *testing.T) {
 
 func TestRepartitionType(t *testing.T) {
 	slice := bigslice.Const(1, []int{}, []string{})
-	expectTypeError(t, "repartiton: expected func(int, int, string) int, got func() int", func() {
+	expectTypeError(t, "repartition: expected func(int, int, string) int, got func() int", func() {
 		bigslice.Repartition(slice, func() int { return 0 })
 	})
-	expectTypeError(t, "repartiton: expected func(int, int, string) int, got func(int, int, string)", func() {
+	expectTypeError(t, "repartition: expected func(int, int, string) int, got func(int, int, string)", func() {
 		bigslice.Repartition(slice, func(_ int, _ int, _ string) {})
 	})
 }

--- a/slicefunc/func.go
+++ b/slicefunc/func.go
@@ -65,10 +65,10 @@ func (funcSliceType) Prefix() int { return 1 }
 func Of(fn interface{}) (Func, bool) {
 	t := reflect.TypeOf(fn)
 	if t == nil {
-		return Func{}, false
+		return Nil, false
 	}
 	if t.Kind() != reflect.Func {
-		return Func{}, false
+		return Nil, false
 	}
 	in := make([]reflect.Type, t.NumIn())
 	for i := range in {

--- a/slicefunc/func_test.go
+++ b/slicefunc/func_test.go
@@ -12,8 +12,10 @@ import (
 
 func TestFunc(t *testing.T) {
 	ctx := context.Background()
-	f := Of(func(x, y int) int { return x + y })
-
+	f, ok := Of(func(x, y int) int { return x + y })
+	if !ok {
+		t.Fatalf("unexpected bad func")
+	}
 	rv := f.Call(ctx, []reflect.Value{reflect.ValueOf(1), reflect.ValueOf(2)})
 	if got, want := len(rv), 1; got != want {
 		t.Fatalf("got %v, want %v", got, want)
@@ -22,9 +24,12 @@ func TestFunc(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	f = Of(func(pctx context.Context, x, y int) bool {
+	f, ok = Of(func(pctx context.Context, x, y int) bool {
 		return x+y == 3 && pctx == ctx
 	})
+	if !ok {
+		t.Fatalf("unexpected bad func")
+	}
 	rv = f.Call(ctx, []reflect.Value{reflect.ValueOf(1), reflect.ValueOf(2)})
 	if got, want := len(rv), 1; got != want {
 		t.Fatalf("got %v, want %v", got, want)

--- a/sortio/sort_test.go
+++ b/sortio/sort_test.go
@@ -237,7 +237,11 @@ func TestReduceReader(t *testing.T) {
 	for i := range readers {
 		readers[i] = sliceio.FrameReader(f)
 	}
-	reducer := Reduce(f, "testreduce", readers, slicefunc.Of(func(x, y int) int { return x + y }))
+	fn, ok := slicefunc.Of(func(x, y int) int { return x + y })
+	if !ok {
+		t.Fatal("unexpected bad func")
+	}
+	reducer := Reduce(f, "testreduce", readers, fn)
 	var (
 		outIntsKey []int
 		outStrsKey []string


### PR DESCRIPTION
Eliminate some false typecheck failures of map functions:
* Handle variadic map functions.
* Handle map functions that accept interface parameters that are passed concrete implementations.

This is not complete across all user function typechecking. There are other places where typechecking has false failures, but we can deal with them later, as I think they're less likely to be problematic. We've had real-world requests for variadic map functions.