### PR TITLE
Guard nil error maybeTaskFatalErr construction

### DIFF
--- a/exec/bigmachine.go
+++ b/exec/bigmachine.go
@@ -913,10 +913,10 @@ func (w *worker) Run(ctx context.Context, req taskRunRequest, reply *taskRunRepl
 	case task.NumOut() == 0:
 		// If there are no output columns, just drive the computation.
 		_, err := out.Read(ctx, frame.Empty)
-		if err == sliceio.EOF {
-			err = nil
+		if err != nil && err != sliceio.EOF {
+			return maybeTaskFatalErr{err}
 		}
-		return maybeTaskFatalErr{err}
+		return nil
 	case task.NumPartition > 1:
 		var psize = *defaultChunksize / 100
 		var (


### PR DESCRIPTION
Otherwise, you get a very confusing error message like:
```
inv1_const_map_scan@2:1 error: %!v(PANIC=Error method: runtime error: invalid memory address or nil pointer dereference)
```

This is because we construct a (non-`nil`) `maybeTaskFatalErr` error that holds a `nil` error. The error gets swallowed by `reviseSeverity`, so this shouldn't change computation behavior, but we've already printed the confusing error by then.