### PR TITLE
Upgrade golangci-lint-action to v1.29

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Check out
       uses: actions/checkout@v2
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v1
+      uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.27
+        version: v1.29
         only-new-issues: true


### PR DESCRIPTION
This upgrades works with the `set-env` vulnerability fix in GitHub Actions.  See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ .